### PR TITLE
refactor(serve): add custom parser function for --port option

### DIFF
--- a/src/commands/search/index.test.ts
+++ b/src/commands/search/index.test.ts
@@ -150,37 +150,45 @@ describe('Search Command', () => {
     )
   })
 
-  describe('should warn log when limit is out of range', () => {
-    it.each([0, 21, 'a'])('should warn when limit is %s', async (limit) => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      const mockResponse = { hits: [] }
+  it('should warn when limit is over 20 and default to 5', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const mockResponse = { hits: [] }
 
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      })
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    })
 
+    searchCommand(program)
+
+    await program.parseAsync(['node', 'test', 'search', 'test', '--limit', '21'])
+
+    expect(warnSpy).toHaveBeenCalledWith('Limit must be a number between 1 and 20\n')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://1GIFSU1REV-dsn.algolia.net/1/indexes/hono/query',
+      {
+        method: 'POST',
+        headers: {
+          'X-Algolia-API-Key': 'c6a0f86b9a9f8551654600f28317a9e9',
+          'X-Algolia-Application-Id': '1GIFSU1REV',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: 'test',
+          hitsPerPage: 5,
+        }),
+      }
+    )
+  })
+
+  describe('should throw error for invalid limit', () => {
+    it.each([0, 'a'])('should throw error when limit is %s', async (limit) => {
       searchCommand(program)
 
-      await program.parseAsync(['node', 'test', 'search', 'test', '--limit', String(limit)])
-
-      expect(warnSpy).toHaveBeenCalledWith('Limit must be a number between 1 and 20\n')
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://1GIFSU1REV-dsn.algolia.net/1/indexes/hono/query',
-        {
-          method: 'POST',
-          headers: {
-            'X-Algolia-API-Key': 'c6a0f86b9a9f8551654600f28317a9e9',
-            'X-Algolia-Application-Id': '1GIFSU1REV',
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            query: 'test',
-            hitsPerPage: 5,
-          }),
-        }
-      )
+      await expect(
+        program.parseAsync(['node', 'test', 'search', 'test', '--limit', String(limit)])
+      ).rejects.toThrow()
     })
   })
 })

--- a/src/commands/search/index.ts
+++ b/src/commands/search/index.ts
@@ -35,7 +35,10 @@ export function searchCommand(program: Command) {
     .argument('<query>', 'Search query for Hono documentation')
     .option('-l, --limit <number>', 'Number of results to show (default: 5)', (value) => {
       const parsed = parseInt(value, 10)
-      if (isNaN(parsed) || parsed < 1 || parsed > 20) {
+      if (isNaN(parsed) || parsed < 1) {
+        throw new Error(`Limit must be a number between 1 and 20. Received: ${value}\n`)
+      }
+      if (parsed > 20) {
         console.warn('Limit must be a number between 1 and 20\n')
         return 5
       }

--- a/src/commands/serve/index.test.ts
+++ b/src/commands/serve/index.test.ts
@@ -276,30 +276,16 @@ describe('serveCommand', () => {
 
   describe('port validation', () => {
     it.each(['-1', '65536', '2048GB', 'invalid'])(
-      'should warn and use default port when port is %s',
+      'should throw error when port is invalid %s',
       async (port) => {
-        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
         mockModules.existsSync.mockReturnValue(false)
         mockModules.resolve.mockImplementation((cwd: string, path: string) => {
           return `${cwd}/${path}`
         })
 
-        await program.parseAsync(['node', 'test', 'serve', '-p', port])
-
-        expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'Port must be a number between 0 and 65535. Using default port 7070.\n'
+        expect(program.parseAsync(['node', 'test', 'serve', '-p', port])).rejects.toThrow(
+          `Port must be a number between 0 and 65535. Received: ${port}\n`
         )
-
-        expect(mockServe).toHaveBeenCalledWith(
-          expect.objectContaining({
-            fetch: expect.any(Function),
-            port: 7070,
-          }),
-          expect.any(Function)
-        )
-
-        consoleWarnSpy.mockRestore()
       }
     )
   })

--- a/src/commands/serve/index.ts
+++ b/src/commands/serve/index.ts
@@ -21,10 +21,9 @@ export function serveCommand(program: Command) {
     .description('Start server')
     .argument('[entry]', 'entry file')
     .option('-p, --port <port>', 'port number', (value) => {
-      const parsed = parseInt(value, 10) // 2048GB will be 2048. So we need to check the original value which consists of only digits.
+      const parsed = parseInt(value, 10)
       if (!/^\d+$/.test(value) || parsed < 0 || parsed > 65535) {
-        console.warn('Port must be a number between 0 and 65535. Using default port 7070.\n')
-        return 7070
+        throw new Error(`Port must be a number between 0 and 65535. Received: ${value}\n`)
       }
       return parsed
     })


### PR DESCRIPTION
Continued from https://github.com/honojs/cli/pull/41 

- As with #41, verify whether the value is valid as Port Number
- add test code