### PR TITLE
chore: convert to runner ubuntu-slim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       matrix:
         node-version: [20, 22, 24]


### PR DESCRIPTION
Since the current CI of Hono CLI is small, how about introducing [ubuntu-slim](https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/)?
(It will take about 10 seconds extra...)