### PR TITLE
feat: replace commander with @takojs/tako

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@hono/cli",
       "dependencies": {
         "@hono/node-server": "^1.19.5",
-        "@takojs/tako": "^1.3.0",
+        "@takojs/tako": "^1.4.0",
         "esbuild": "^0.25.10",
         "hono": "^4.9.12",
       },
@@ -228,7 +228,7 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
 
-    "@takojs/tako": ["@takojs/tako@1.3.0", "", {}, "sha512-vefFTQykYUohsTNB3Z1jNkP4mKtpRCLodJONqKGtw+XWxt9JoGoDdGo9ZeFDzj2VFJjWS2zbuQTKMgtKPVHAMQ=="],
+    "@takojs/tako": ["@takojs/tako@1.4.0", "", {}, "sha512-nV5Y2dSFgTA/KAvCdsXYWGKtI6yox590eBeNomyJYoajkUFYpKJqElsG6VHNxTlBPVrZr9RP93+MBgCjcXTAKg=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@hono/cli",
       "dependencies": {
         "@hono/node-server": "^1.19.5",
-        "@takojs/tako": "^1.1.0",
+        "@takojs/tako": "^1.3.0",
         "esbuild": "^0.25.10",
         "hono": "^4.9.12",
       },
@@ -228,7 +228,7 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
 
-    "@takojs/tako": ["@takojs/tako@1.1.0", "", {}, "sha512-rRJS/KwTe3DOFvj6TFQr3JIYSb/e528BHgHg0+JnbNSxjgWXrrdiW33PtRcJogZfUis4MIdJkobDZWNAedS9HA=="],
+    "@takojs/tako": ["@takojs/tako@1.3.0", "", {}, "sha512-vefFTQykYUohsTNB3Z1jNkP4mKtpRCLodJONqKGtw+XWxt9JoGoDdGo9ZeFDzj2VFJjWS2zbuQTKMgtKPVHAMQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@hono/cli",
       "dependencies": {
         "@hono/node-server": "^1.19.5",
-        "commander": "^14.0.1",
+        "@takojs/tako": "^1.1.0",
         "esbuild": "^0.25.10",
         "hono": "^4.9.12",
       },
@@ -227,6 +228,8 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
 
+    "@takojs/tako": ["@takojs/tako@1.1.0", "", {}, "sha512-rRJS/KwTe3DOFvj6TFQr3JIYSb/e528BHgHg0+JnbNSxjgWXrrdiW33PtRcJogZfUis4MIdJkobDZWNAedS9HA=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/chai": ["@types/chai@5.2.2", "", { "dependencies": { "@types/deep-eql": "*" } }, "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg=="],
@@ -381,7 +384,7 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "commander": ["commander@14.0.1", "", {}, "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A=="],
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "comment-parser": ["comment-parser@1.4.1", "", {}, "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg=="],
 
@@ -1110,8 +1113,6 @@
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "update-notifier/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI for Hono",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://hono.dev",
   "dependencies": {
     "@hono/node-server": "^1.19.5",
-    "@takojs/tako": "^1.3.0",
+    "@takojs/tako": "^1.4.0",
     "esbuild": "^0.25.10",
     "hono": "^4.9.12"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hono/cli",
   "version": "0.1.0",
+  "description": "CLI for Hono",
   "type": "module",
   "bin": {
     "hono": "dist/cli.js"
@@ -34,7 +35,7 @@
   "homepage": "https://hono.dev",
   "dependencies": {
     "@hono/node-server": "^1.19.5",
-    "commander": "^14.0.1",
+    "@takojs/tako": "^1.1.0",
     "esbuild": "^0.25.10",
     "hono": "^4.9.12"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://hono.dev",
   "dependencies": {
     "@hono/node-server": "^1.19.5",
-    "@takojs/tako": "^1.1.0",
+    "@takojs/tako": "^1.3.0",
     "esbuild": "^0.25.10",
     "hono": "^4.9.12"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { Tako } from '@takojs/tako'
 import pkg from '../package.json' with { type: 'json' }
 import { docsArgs, docsCommand, docsValidation } from './commands/docs/index.js'
-// import { optimizeArgs, optimizeCommand, optimizeValidation } from './commands/optimize/index.js' // TODO: replace commander with @takojs/tako
+import { optimizeArgs, optimizeCommand, optimizeValidation } from './commands/optimize/index.js'
 import { requestArgs, requestCommand, requestValidation } from './commands/request/index.js'
 import { searchArgs, searchCommand, searchValidation } from './commands/search/index.js'
 import { serveArgs, serveCommand, serveValidation } from './commands/serve/index.js'
@@ -18,7 +18,7 @@ const tako = new Tako()
 
 // Register commands
 tako.command('docs', docsArgs, docsValidation, docsCommand)
-// tako.command("optimize", optimizeArgs, optimizeValidation, optimizeCommand) // TODO: replace commander with @takojs/tako
+tako.command('optimize', optimizeArgs, optimizeValidation, optimizeCommand)
 tako.command('request', requestArgs, requestValidation, requestCommand)
 tako.command('search', searchArgs, searchValidation, searchCommand)
 tako.command('serve', serveArgs, serveValidation, serveCommand)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { serveArgs, serveCommand, serveValidation } from './commands/serve/index
 
 const rootArgs = {
   metadata: {
+    cliName: "hono",
     version: pkg.version,
     help: pkg.description,
   },
@@ -22,4 +23,4 @@ tako.command('request', requestArgs, requestValidation, requestCommand)
 tako.command('search', searchArgs, searchValidation, searchCommand)
 tako.command('serve', serveArgs, serveValidation, serveCommand)
 
-tako.cli(rootArgs)
+await tako.cli(rootArgs)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { serveArgs, serveCommand, serveValidation } from './commands/serve/index
 
 const rootArgs = {
   metadata: {
-    cliName: "hono",
+    cliName: 'hono',
     version: pkg.version,
     help: pkg.description,
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,31 +1,25 @@
-import { Command } from 'commander'
-import { readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { docsCommand } from './commands/docs/index.js'
-import { optimizeCommand } from './commands/optimize/index.js'
-import { requestCommand } from './commands/request/index.js'
-import { searchCommand } from './commands/search/index.js'
-import { serveCommand } from './commands/serve/index.js'
+import { Tako } from '@takojs/tako'
+import pkg from '../package.json' with { type: 'json' }
+import { docsArgs, docsCommand, docsValidation } from './commands/docs/index.js'
+// import { optimizeArgs, optimizeCommand, optimizeValidation } from './commands/optimize/index.js' // TODO: replace commander with @takojs/tako
+import { requestArgs, requestCommand, requestValidation } from './commands/request/index.js'
+import { searchArgs, searchCommand, searchValidation } from './commands/search/index.js'
+import { serveArgs, serveCommand, serveValidation } from './commands/serve/index.js'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
+const rootArgs = {
+  metadata: {
+    version: pkg.version,
+    help: pkg.description,
+  },
+}
 
-// Read version from package.json
-const packageJson = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8'))
-
-const program = new Command()
-
-program
-  .name('hono')
-  .description('CLI for Hono')
-  .version(packageJson.version, '-v, --version', 'display version number')
+const tako = new Tako()
 
 // Register commands
-docsCommand(program)
-optimizeCommand(program)
-searchCommand(program)
-requestCommand(program)
-serveCommand(program)
+tako.command('docs', docsArgs, docsValidation, docsCommand)
+// tako.command("optimize", optimizeArgs, optimizeValidation, optimizeCommand) // TODO: replace commander with @takojs/tako
+tako.command('request', requestArgs, requestValidation, requestCommand)
+tako.command('search', searchArgs, searchValidation, searchCommand)
+tako.command('serve', serveArgs, serveValidation, serveCommand)
 
-program.parse()
+tako.cli(rootArgs)

--- a/src/commands/docs/index.test.ts
+++ b/src/commands/docs/index.test.ts
@@ -1,20 +1,21 @@
-import { Command } from 'commander'
+import { Tako } from '@takojs/tako'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Buffer } from 'node:buffer'
+import * as process from 'node:process'
+import { docsArgs, docsCommand, docsValidation } from './index.js'
 
 // Mock fetch
-global.fetch = vi.fn()
-
-import { docsCommand } from './index.js'
+globalThis.fetch = vi.fn()
 
 describe('docsCommand', () => {
-  let program: Command
+  let tako: Tako
   let consoleLogSpy: ReturnType<typeof vi.spyOn>
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>
   let originalIsTTY: boolean | undefined
 
   beforeEach(() => {
-    program = new Command()
-    docsCommand(program)
+    tako = new Tako()
+    tako.command('docs', docsArgs, docsValidation, docsCommand)
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
@@ -46,7 +47,7 @@ describe('docsCommand', () => {
       text: () => Promise.resolve(mockContent),
     } as Response)
 
-    await program.parseAsync(['node', 'test', 'docs'])
+    await tako.cli({ config: { args: ['docs'] } })
 
     expect(fetch).toHaveBeenCalledWith('https://hono.dev/llms.txt')
     expect(consoleLogSpy).toHaveBeenCalledWith('Fetching Hono documentation...')
@@ -61,7 +62,7 @@ describe('docsCommand', () => {
       text: () => Promise.resolve(mockMarkdown),
     } as Response)
 
-    await program.parseAsync(['node', 'test', 'docs', '/docs/concepts/stacks'])
+    await tako.cli({ config: { args: ['docs', '/docs/concepts/stacks'] } })
 
     expect(fetch).toHaveBeenCalledWith(
       'https://raw.githubusercontent.com/honojs/website/refs/heads/main/docs/concepts/stacks.md'
@@ -80,7 +81,7 @@ describe('docsCommand', () => {
       text: () => Promise.resolve(mockMarkdown),
     } as Response)
 
-    await program.parseAsync(['node', 'test', 'docs', '/examples/stytch-auth'])
+    await tako.cli({ config: { args: ['docs', '/examples/stytch-auth'] } })
 
     expect(fetch).toHaveBeenCalledWith(
       'https://raw.githubusercontent.com/honojs/website/refs/heads/main/examples/stytch-auth.md'
@@ -99,7 +100,7 @@ describe('docsCommand', () => {
       text: () => Promise.resolve(mockMarkdown),
     } as Response)
 
-    await program.parseAsync(['node', 'test', 'docs', 'examples/basic'])
+    await tako.cli({ config: { args: ['docs', 'examples/basic'] } })
 
     expect(fetch).toHaveBeenCalledWith(
       'https://raw.githubusercontent.com/honojs/website/refs/heads/main/examples/basic.md'
@@ -115,7 +116,7 @@ describe('docsCommand', () => {
       statusText: 'Not Found',
     } as Response)
 
-    await program.parseAsync(['node', 'test', 'docs'])
+    await tako.cli({ config: { args: ['docs'] } })
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'Error fetching documentation:',
@@ -131,7 +132,7 @@ describe('docsCommand', () => {
       statusText: 'Not Found',
     } as Response)
 
-    await program.parseAsync(['node', 'test', 'docs', '/docs/concepts/motivation'])
+    await tako.cli({ config: { args: ['docs', '/docs/concepts/motivation'] } })
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'Error fetching documentation:',
@@ -149,7 +150,7 @@ describe('docsCommand', () => {
       statusText: 'Not Found',
     } as Response)
 
-    await program.parseAsync(['node', 'test', 'docs', '/examples/stytch-auth'])
+    await tako.cli({ config: { args: ['docs', '/examples/stytch-auth'] } })
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'Error fetching documentation:',
@@ -164,7 +165,7 @@ describe('docsCommand', () => {
     const networkError = new Error('Network error')
     vi.mocked(fetch).mockRejectedValue(networkError)
 
-    await program.parseAsync(['node', 'test', 'docs'])
+    await tako.cli({ config: { args: ['docs'] } })
 
     expect(consoleErrorSpy).toHaveBeenCalledWith('Error fetching documentation:', 'Network error')
     expect(consoleLogSpy).toHaveBeenCalledWith('\nPlease visit: https://hono.dev/docs')
@@ -189,7 +190,8 @@ describe('docsCommand', () => {
       text: () => Promise.resolve(mockMarkdown),
     } as Response)
 
-    await program.parseAsync(['node', 'test', 'docs'])
+    await tako.cli({ config: { args: ['docs'] } })
+    await new Promise(process.nextTick)
 
     expect(fetch).toHaveBeenCalledWith(
       'https://raw.githubusercontent.com/honojs/website/refs/heads/main/docs/concepts/middleware.md'
@@ -222,7 +224,8 @@ describe('docsCommand', () => {
       text: () => Promise.resolve(mockMarkdown),
     } as Response)
 
-    await program.parseAsync(['node', 'test', 'docs'])
+    await tako.cli({ config: { args: ['docs'] } })
+    await new Promise(process.nextTick)
 
     expect(fetch).toHaveBeenCalledWith(
       'https://raw.githubusercontent.com/honojs/website/refs/heads/main/docs/api/context.md'
@@ -246,7 +249,7 @@ describe('docsCommand', () => {
       text: () => Promise.resolve(mockContent),
     } as Response)
 
-    await program.parseAsync(['node', 'test', 'docs'])
+    await tako.cli({ config: { args: ['docs'] } })
 
     expect(fetch).toHaveBeenCalledWith('https://hono.dev/llms.txt')
     expect(consoleLogSpy).toHaveBeenCalledWith('Fetching Hono documentation...')

--- a/src/commands/docs/index.test.ts
+++ b/src/commands/docs/index.test.ts
@@ -191,7 +191,6 @@ describe('docsCommand', () => {
     } as Response)
 
     await tako.cli({ config: { args: ['docs'] } })
-    await new Promise(process.nextTick)
 
     expect(fetch).toHaveBeenCalledWith(
       'https://raw.githubusercontent.com/honojs/website/refs/heads/main/docs/concepts/middleware.md'
@@ -225,7 +224,6 @@ describe('docsCommand', () => {
     } as Response)
 
     await tako.cli({ config: { args: ['docs'] } })
-    await new Promise(process.nextTick)
 
     expect(fetch).toHaveBeenCalledWith(
       'https://raw.githubusercontent.com/honojs/website/refs/heads/main/docs/api/context.md'

--- a/src/commands/docs/index.ts
+++ b/src/commands/docs/index.ts
@@ -31,8 +31,8 @@ export const docsArgs: TakoArgs = {
   },
 }
 
-export const docsValidation: TakoHandler = (_c, next) => {
-  next()
+export const docsValidation: TakoHandler = async (_c, next) => {
+  await next()
 }
 
 export const docsCommand: TakoHandler = async (c) => {
@@ -56,7 +56,7 @@ export const docsCommand: TakoHandler = async (c) => {
         c.print({
           message: [
             'Error reading from stdin:',
-            error instanceof Error ? error.message : String(error)
+            error instanceof Error ? error.message : String(error),
           ],
           style: 'red',
           level: 'error',

--- a/src/commands/docs/index.ts
+++ b/src/commands/docs/index.ts
@@ -1,6 +1,8 @@
-import type { Command } from 'commander'
+import type { Tako, TakoArgs, TakoHandler } from '@takojs/tako'
+import { Buffer } from 'node:buffer'
+import * as process from 'node:process'
 
-async function fetchAndDisplayContent(url: string, fallbackUrl?: string): Promise<void> {
+async function fetchAndDisplayContent(c: Tako, url: string, fallbackUrl?: string): Promise<void> {
   try {
     const response = await fetch(url)
 
@@ -9,64 +11,75 @@ async function fetchAndDisplayContent(url: string, fallbackUrl?: string): Promis
     }
 
     const content = await response.text()
-    console.log('\n' + content)
+    c.print({ message: '\n' + content })
   } catch (error) {
-    console.error(
-      'Error fetching documentation:',
-      error instanceof Error ? error.message : String(error)
-    )
-    console.log(`\nPlease visit: ${fallbackUrl || 'https://hono.dev/docs'}`)
+    c.print({
+      message: [
+        'Error fetching documentation:',
+        error instanceof Error ? error.message : String(error),
+      ],
+      style: 'red',
+      level: 'error',
+    })
+    c.print({ message: `\nPlease visit: ${fallbackUrl || 'https://hono.dev/docs'}` })
   }
 }
 
-export function docsCommand(program: Command) {
-  program
-    .command('docs')
-    .argument(
-      '[path]',
-      'Documentation path (e.g., /docs/concepts/motivation, /examples/stytch-auth)',
-      ''
-    )
-    .description('Display Hono documentation')
-    .action(async (path: string) => {
-      let finalPath = path
+export const docsArgs: TakoArgs = {
+  metadata: {
+    help: 'Display Hono documentation',
+  },
+}
 
-      // If no path provided, check for stdin input
-      if (!path) {
-        // Check if stdin is piped (not a TTY)
-        if (!process.stdin.isTTY) {
-          try {
-            const chunks: Buffer[] = []
-            for await (const chunk of process.stdin) {
-              chunks.push(chunk)
-            }
-            const stdinInput = Buffer.concat(chunks).toString().trim()
-            if (stdinInput) {
-              // Remove quotes if present (handles jq output without -r flag)
-              finalPath = stdinInput.replace(/^["'](.*)["']$/, '$1')
-            }
-          } catch (error) {
-            console.error('Error reading from stdin:', error)
-          }
-        }
+export const docsValidation: TakoHandler = (_c, next) => {
+  next()
+}
 
-        // If still no path, fetch llms.txt
-        if (!finalPath) {
-          console.log('Fetching Hono documentation...')
-          await fetchAndDisplayContent('https://hono.dev/llms.txt')
-          return
+export const docsCommand: TakoHandler = async (c) => {
+  let finalPath = c.scriptArgs.positionals[0]
+
+  // If no path provided, check for stdin input
+  if (!finalPath) {
+    // Check if stdin is piped (not a TTY)
+    if (!process.stdin.isTTY) {
+      try {
+        const chunks: Buffer[] = []
+        for await (const chunk of process.stdin) {
+          chunks.push(chunk)
         }
+        const stdinInput = Buffer.concat(chunks).toString().trim()
+        if (stdinInput) {
+          // Remove quotes if present (handles jq output without -r flag)
+          finalPath = stdinInput.replace(/^["'](.*)["']$/, '$1')
+        }
+      } catch (error) {
+        c.print({
+          message: [
+            'Error reading from stdin:',
+            error instanceof Error ? error.message : String(error)
+          ],
+          style: 'red',
+          level: 'error',
+        })
       }
+    }
 
-      // Ensure path starts with /
-      const normalizedPath = finalPath.startsWith('/') ? finalPath : `/${finalPath}`
+    // If still no path, fetch llms.txt
+    if (!finalPath) {
+      c.print({ message: 'Fetching Hono documentation...' })
+      await fetchAndDisplayContent(c, 'https://hono.dev/llms.txt')
+      return
+    }
+  }
 
-      // Remove leading slash to get the GitHub path
-      const basePath = normalizedPath.slice(1) // Remove leading slash
-      const markdownUrl = `https://raw.githubusercontent.com/honojs/website/refs/heads/main/${basePath}.md`
-      const webUrl = `https://hono.dev${normalizedPath}`
+  // Ensure path starts with /
+  const normalizedPath = finalPath.startsWith('/') ? finalPath : `/${finalPath}`
 
-      console.log(`Fetching Hono documentation for ${finalPath}...`)
-      await fetchAndDisplayContent(markdownUrl, webUrl)
-    })
+  // Remove leading slash to get the GitHub path
+  const basePath = normalizedPath.slice(1) // Remove leading slash
+  const markdownUrl = `https://raw.githubusercontent.com/honojs/website/refs/heads/main/${basePath}.md`
+  const webUrl = `https://hono.dev${normalizedPath}`
+
+  c.print({ message: `Fetching Hono documentation for ${finalPath}...` })
+  await fetchAndDisplayContent(c, markdownUrl, webUrl)
 }

--- a/src/commands/optimize/index.test.ts
+++ b/src/commands/optimize/index.test.ts
@@ -1,13 +1,14 @@
-import { Command } from 'commander'
-import { describe, it, expect, beforeEach } from 'vitest'
+import { Tako } from '@takojs/tako'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { execFile } from 'node:child_process'
 import { mkdirSync, mkdtempSync, writeFileSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { optimizeCommand } from './index'
+import * as process from 'node:process'
+import { optimizeArgs, optimizeCommand, optimizeValidation } from './index'
 
-const program = new Command()
-optimizeCommand(program)
+const tako = new Tako()
+tako.command('optimize', optimizeArgs, optimizeValidation, optimizeCommand)
 
 const npmInstall = async () =>
   new Promise<void>((resolve) => {
@@ -27,7 +28,7 @@ describe('optimizeCommand', () => {
 
   it('should throws an error if entry file not found', async () => {
     await expect(
-      program.parseAsync(['node', 'hono', 'optimize', './non-existent-file.ts'])
+      tako.cli({ config: { args: ['optimize', './non-existent-file.ts'] } })
     ).rejects.toThrowError()
   })
 
@@ -216,7 +217,7 @@ describe('optimizeCommand', () => {
       for (const file of files) {
         writeFileSync(join(dir, file.path), file.content)
       }
-      await program.parseAsync(['node', 'hono', 'optimize', ...(args ?? [])])
+      await tako.cli({ config: { args: ['optimize', ...(args ?? [])] } })
 
       const content = readFileSync(join(dir, result.path), 'utf-8')
       if (result.lineCount) {

--- a/src/commands/optimize/index.ts
+++ b/src/commands/optimize/index.ts
@@ -1,116 +1,146 @@
-import type { Command } from 'commander'
+import type { TakoArgs, TakoHandler } from '@takojs/tako'
 import * as esbuild from 'esbuild'
 import type { Hono } from 'hono'
 import { buildInitParams, serializeInitParams } from 'hono/router/reg-exp-router'
 import { execFile } from 'node:child_process'
 import { existsSync, realpathSync, statSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
+import * as process from 'node:process'
 import { buildAndImportApp } from '../../utils/build.js'
 
 const DEFAULT_ENTRY_CANDIDATES = ['src/index.ts', 'src/index.tsx', 'src/index.js', 'src/index.jsx']
 
-export function optimizeCommand(program: Command) {
-  program
-    .command('optimize')
-    .description('Build optimized Hono class')
-    .argument('[entry]', 'entry file')
-    .option('-o, --outfile [outfile]', 'output file', 'dist/index.js')
-    .option('-m, --minify', 'minify output file')
-    .action(async (entry: string, options: { outfile: string; minify?: boolean }) => {
-      if (!entry) {
-        entry =
-          DEFAULT_ENTRY_CANDIDATES.find((entry) => existsSync(entry)) ?? DEFAULT_ENTRY_CANDIDATES[0]
-      }
+export const optimizeArgs: TakoArgs = {
+  config: {
+    options: {
+      outfile: {
+        type: 'string',
+        short: 'o',
+        default: 'dist/index.js',
+      },
+      minify: {
+        type: 'boolean',
+        short: 'm',
+      },
+    },
+  },
+  metadata: {
+    help: 'Build optimized Hono class',
+    placeholder: '[entry]',
+    options: {
+      outfile: {
+        help: 'output file',
+        placeholder: '<outfile>',
+      },
+      minify: {
+        help: 'minify output file',
+      },
+    },
+  },
+}
 
-      const appPath = resolve(process.cwd(), entry)
+export const optimizeValidation: TakoHandler = async (_c, next) => {
+  await next()
+}
 
-      if (!existsSync(appPath)) {
-        throw new Error(`Entry file ${entry} does not exist`)
-      }
+export const optimizeCommand: TakoHandler = async (c) => {
+  let entry = c.scriptArgs.positionals[0]
+  const { outfile, minify } = c.scriptArgs.values as { outfile?: string; minify?: boolean }
+  if (!entry) {
+    entry =
+      DEFAULT_ENTRY_CANDIDATES.find((entry) => existsSync(entry)) ?? DEFAULT_ENTRY_CANDIDATES[0]
+  }
 
-      const appFilePath = realpathSync(appPath)
-      const app: Hono = await buildAndImportApp(appFilePath, {
-        external: ['@hono/node-server'],
+  const appPath = resolve(process.cwd(), entry)
+
+  if (!existsSync(appPath)) {
+    throw new Error(`Entry file ${entry} does not exist`)
+  }
+
+  const appFilePath = realpathSync(appPath)
+  const app: Hono = await buildAndImportApp(appFilePath, {
+    external: ['@hono/node-server'],
+  })
+
+  let routerName
+  let importStatement
+  let assignRouterStatement
+  try {
+    const serialized = serializeInitParams(
+      buildInitParams({
+        paths: app.routes.map(({ path }) => path),
       })
+    )
 
-      let routerName
-      let importStatement
-      let assignRouterStatement
-      try {
-        const serialized = serializeInitParams(
-          buildInitParams({
-            paths: app.routes.map(({ path }) => path),
-          })
-        )
+    const hasPreparedRegExpRouter = await new Promise<boolean>((resolve) => {
+      const child = execFile(process.execPath, [
+        '--input-type=module',
+        '-e',
+        "try { (await import('hono/router/reg-exp-router')).PreparedRegExpRouter && process.exit(0) } finally { process.exit(1) }",
+      ])
+      child.on('exit', (code) => {
+        resolve(code === 0)
+      })
+    })
 
-        const hasPreparedRegExpRouter = await new Promise<boolean>((resolve) => {
-          const child = execFile(process.execPath, [
-            '--input-type=module',
-            '-e',
-            "try { (await import('hono/router/reg-exp-router')).PreparedRegExpRouter && process.exit(0) } finally { process.exit(1) }",
-          ])
-          child.on('exit', (code) => {
-            resolve(code === 0)
-          })
-        })
-
-        if (hasPreparedRegExpRouter) {
-          routerName = 'PreparedRegExpRouter'
-          importStatement = "import { PreparedRegExpRouter } from 'hono/router/reg-exp-router'"
-          assignRouterStatement = `const routerParams = ${serialized}
+    if (hasPreparedRegExpRouter) {
+      routerName = 'PreparedRegExpRouter'
+      importStatement = "import { PreparedRegExpRouter } from 'hono/router/reg-exp-router'"
+      assignRouterStatement = `const routerParams = ${serialized}
     this.router = new PreparedRegExpRouter(...routerParams)`
-        } else {
-          routerName = 'RegExpRouter'
-          importStatement = "import { RegExpRouter } from 'hono/router/reg-exp-router'"
-          assignRouterStatement = 'this.router = new RegExpRouter()'
-        }
-      } catch {
-        // fallback to default router
-        routerName = 'TrieRouter'
-        importStatement = "import { TrieRouter } from 'hono/router/trie-router'"
-        assignRouterStatement = 'this.router = new TrieRouter()'
-      }
+    } else {
+      routerName = 'RegExpRouter'
+      importStatement = "import { RegExpRouter } from 'hono/router/reg-exp-router'"
+      assignRouterStatement = 'this.router = new RegExpRouter()'
+    }
+  } catch {
+    // fallback to default router
+    routerName = 'TrieRouter'
+    importStatement = "import { TrieRouter } from 'hono/router/trie-router'"
+    assignRouterStatement = 'this.router = new TrieRouter()'
+  }
 
-      console.log('[Optimized]')
-      console.log(`  Router: ${routerName}`)
+  console.log('[Optimized]')
+  console.log(`  Router: ${routerName}`)
 
-      const outfile = resolve(process.cwd(), options.outfile)
-      await esbuild.build({
-        entryPoints: [appFilePath],
-        outfile,
-        bundle: true,
-        minify: options.minify,
-        format: 'esm',
-        target: 'node20',
-        platform: 'node',
-        jsx: 'automatic',
-        jsxImportSource: 'hono/jsx',
-        plugins: [
-          {
-            name: 'hono-optimize',
-            setup(build) {
-              const honoPseudoImportPath = 'hono-optimized-pseudo-import-path'
+  const outputFilename = outfile || 'dist/index.js'
+  const absoluteOutfile = resolve(process.cwd(), outputFilename)
+  await esbuild.build({
+    entryPoints: [appFilePath],
+    outfile: absoluteOutfile,
+    bundle: true,
+    minify: minify,
+    format: 'esm',
+    target: 'node20',
+    platform: 'node',
+    jsx: 'automatic',
+    jsxImportSource: 'hono/jsx',
+    plugins: [
+      {
+        name: 'hono-optimize',
+        setup(build) {
+          const honoPseudoImportPath = 'hono-optimized-pseudo-import-path'
 
-              build.onResolve({ filter: /^hono$/ }, async (args) => {
-                if (!args.importer) {
-                  // prevent recursive resolution of "hono"
-                  return undefined
-                }
+          build.onResolve({ filter: /^hono$/ }, async (args) => {
+            if (!args.importer) {
+              // prevent recursive resolution of "hono"
+              return undefined
+            }
 
-                // resolve original import path for "hono"
-                const resolved = await build.resolve(args.path, {
-                  kind: 'import-statement',
-                  resolveDir: args.resolveDir,
-                })
+            // resolve original import path for "hono"
+            const resolved = await build.resolve(args.path, {
+              kind: 'import-statement',
+              resolveDir: args.resolveDir,
+            })
 
-                // mark "honoOptimize" to the resolved path for filtering
-                return {
-                  path: join(dirname(resolved.path), honoPseudoImportPath),
-                }
-              })
-              build.onLoad({ filter: new RegExp(`/${honoPseudoImportPath}$`) }, async () => {
-                return {
-                  contents: `
+            // mark "honoOptimize" to the resolved path for filtering
+            return {
+              path: join(dirname(resolved.path), honoPseudoImportPath),
+            }
+          })
+          build.onLoad({ filter: new RegExp(`/${honoPseudoImportPath}$`) }, async () => {
+            return {
+              contents: `
 import { HonoBase } from 'hono/hono-base'
 ${importStatement}
 export class Hono extends HonoBase {
@@ -120,14 +150,13 @@ export class Hono extends HonoBase {
   }
 }
 `,
-                }
-              })
-            },
-          },
-        ],
-      })
+            }
+          })
+        },
+      },
+    ],
+  })
 
-      const outfileStat = statSync(outfile)
-      console.log(`  Output: ${options.outfile} (${(outfileStat.size / 1024).toFixed(2)} KB)`)
-    })
+  const outfileStat = statSync(absoluteOutfile)
+  console.log(`  Output: ${outputFilename} (${(outfileStat.size / 1024).toFixed(2)} KB)`)
 }

--- a/src/commands/optimize/index.ts
+++ b/src/commands/optimize/index.ts
@@ -58,9 +58,10 @@ export const optimizeCommand: TakoHandler = async (c) => {
   }
 
   const appFilePath = realpathSync(appPath)
-  const app: Hono = await buildAndImportApp(appFilePath, {
+  const buildIterator = buildAndImportApp(appFilePath, {
     external: ['@hono/node-server'],
   })
+  const app: Hono = (await buildIterator.next()).value
 
   let routerName
   let importStatement

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -106,7 +106,7 @@ describe('requestCommand', () => {
     const expectedPath = 'test-app.js'
     setupBasicMocks(expectedPath, mockApp)
 
-    await program.parseAsync(['node', 'test', 'request', '-w', '-P', '/', 'test-app.js'])
+    await tako.cli({ config: { args: ['request', '-w', '-P', '/', 'test-app.js'] } })
 
     // Verify resolve was called with correct arguments
     expect(mockModules.resolve).toHaveBeenCalledWith(process.cwd(), 'test-app.js')

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -63,7 +63,6 @@ describe('requestCommand', () => {
     setupBasicMocks(expectedPath, mockApp)
 
     await tako.cli({ config: { args: ['request', '-P', '/', 'test-app.js'] } })
-    await new Promise(process.nextTick)
 
     // Verify resolve was called with correct arguments
     expect(mockModules.resolve).toHaveBeenCalledWith(process.cwd(), 'test-app.js')
@@ -93,19 +92,9 @@ describe('requestCommand', () => {
 
     await tako.cli({
       config: {
-        args: [
-          'request',
-          '-P',
-          '/data',
-          '-X',
-          'POST',
-          '-d',
-          'test data',
-          'test-app.js',
-        ],
+        args: ['request', '-P', '/data', '-X', 'POST', '-d', 'test data', 'test-app.js'],
       },
     })
-    await new Promise(process.nextTick)
 
     // Verify resolve was called with correct arguments
     expect(mockModules.resolve).toHaveBeenCalledWith(process.cwd(), 'test-app.js')
@@ -141,7 +130,6 @@ describe('requestCommand', () => {
     mockBuildAndImportApp.mockResolvedValue(mockApp)
 
     await tako.cli({ config: { args: ['request'] } })
-    await new Promise(process.nextTick)
 
     // Verify resolve was called with correct arguments for default candidates
     expect(mockModules.resolve).toHaveBeenCalledWith(process.cwd(), 'src/index.ts')
@@ -176,17 +164,9 @@ describe('requestCommand', () => {
 
     await tako.cli({
       config: {
-        args: [
-          'request',
-          '-P',
-          '/api/test',
-          '-H',
-          'Authorization: Bearer token123',
-          'test-app.js',
-        ],
+        args: ['request', '-P', '/api/test', '-H', 'Authorization: Bearer token123', 'test-app.js'],
       },
     })
-    await new Promise(process.nextTick)
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
       JSON.stringify(
@@ -229,7 +209,6 @@ describe('requestCommand', () => {
         ],
       },
     })
-    await new Promise(process.nextTick)
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
       JSON.stringify(
@@ -255,7 +234,6 @@ describe('requestCommand', () => {
     setupBasicMocks(expectedPath, mockApp)
 
     await tako.cli({ config: { args: ['request', '-P', '/api/noheader', 'test-app.js'] } })
-    await new Promise(process.nextTick)
 
     // Should not include any custom headers, only default ones
     const output = consoleLogSpy.mock.calls[0][0] as string
@@ -287,7 +265,6 @@ describe('requestCommand', () => {
         ],
       },
     })
-    await new Promise(process.nextTick)
 
     // Should still work, malformed header is ignored
     expect(consoleLogSpy).toHaveBeenCalledWith(

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -137,8 +137,8 @@ export const requestArgs: TakoArgs = {
   },
 }
 
-export const requestValidation: TakoHandler = (_c, next) => {
-  next()
+export const requestValidation: TakoHandler = async (_c, next) => {
+  await next()
 }
 
 export const requestCommand: TakoHandler = async (c) => {

--- a/src/commands/search/index.test.ts
+++ b/src/commands/search/index.test.ts
@@ -63,14 +63,12 @@ describe('Search Command', () => {
       results: [
         {
           title: 'Getting Started',
-          highlightedTitle: 'Getting Started',
           category: '',
           url: 'https://hono.dev/docs/getting-started',
           path: '/docs/getting-started',
         },
         {
           title: 'Middleware',
-          highlightedTitle: 'Middleware',
           category: 'Basic Usage',
           url: 'https://hono.dev/docs/middleware',
           path: '/docs/middleware',

--- a/src/commands/search/index.test.ts
+++ b/src/commands/search/index.test.ts
@@ -1,16 +1,17 @@
-import { Command } from 'commander'
+import { Tako } from '@takojs/tako'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { searchCommand } from './index.js'
+import { searchArgs, searchCommand, searchValidation } from './index.js'
 
 // Mock fetch globally
 const mockFetch = vi.fn()
-global.fetch = mockFetch
+globalThis.fetch = mockFetch
 
 describe('Search Command', () => {
-  let program: Command
+  let tako: Tako
 
   beforeEach(() => {
-    program = new Command()
+    tako = new Tako()
+    tako.command('search', searchArgs, searchValidation, searchCommand)
     vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -44,9 +45,8 @@ describe('Search Command', () => {
     })
 
     const logSpy = vi.spyOn(console, 'log')
-    searchCommand(program)
 
-    await program.parseAsync(['node', 'test', 'search', 'middleware'])
+    await tako.cli({ config: { args: ['search', 'middleware'] } })
 
     // Get the JSON output
     const jsonOutput = logSpy.mock.calls[0][0]
@@ -63,12 +63,14 @@ describe('Search Command', () => {
       results: [
         {
           title: 'Getting Started',
+          highlightedTitle: 'Getting Started',
           category: '',
           url: 'https://hono.dev/docs/getting-started',
           path: '/docs/getting-started',
         },
         {
           title: 'Middleware',
+          highlightedTitle: 'Middleware',
           category: 'Basic Usage',
           url: 'https://hono.dev/docs/middleware',
           path: '/docs/middleware',
@@ -88,9 +90,8 @@ describe('Search Command', () => {
     })
 
     const logSpy = vi.spyOn(console, 'log')
-    searchCommand(program)
 
-    await program.parseAsync(['node', 'test', 'search', 'nonexistent'])
+    await tako.cli({ config: { args: ['search', 'nonexistent'] } })
 
     const jsonOutput = logSpy.mock.calls[0][0]
 
@@ -114,9 +115,7 @@ describe('Search Command', () => {
       statusText: 'Not Found',
     })
 
-    searchCommand(program)
-
-    await program.parseAsync(['node', 'test', 'search', 'test'])
+    await tako.cli({ config: { args: ['search', 'test'] } })
 
     expect(errorSpy).toHaveBeenCalled()
   })
@@ -129,9 +128,7 @@ describe('Search Command', () => {
       json: async () => mockResponse,
     })
 
-    searchCommand(program)
-
-    await program.parseAsync(['node', 'test', 'search', 'test', '--limit', '3'])
+    await tako.cli({ config: { args: ['search', 'test', '--limit', '3'] } })
 
     expect(mockFetch).toHaveBeenCalledWith(
       'https://1GIFSU1REV-dsn.algolia.net/1/indexes/hono/query',
@@ -160,9 +157,7 @@ describe('Search Command', () => {
         json: async () => mockResponse,
       })
 
-      searchCommand(program)
-
-      await program.parseAsync(['node', 'test', 'search', 'test', '--limit', String(limit)])
+      await tako.cli({ config: { args: ['search', 'test', '--limit', String(limit)] } })
 
       expect(warnSpy).toHaveBeenCalledWith('Limit must be a number between 1 and 20\n')
 

--- a/src/commands/search/index.ts
+++ b/src/commands/search/index.ts
@@ -44,6 +44,8 @@ export const searchArgs: TakoArgs = {
   },
   metadata: {
     help: 'Search Hono documentation',
+    required: true,
+    placeholder: '<query>',
     options: {
       limit: {
         help: 'Number of results to show (default: 5)',
@@ -57,10 +59,6 @@ export const searchArgs: TakoArgs = {
 }
 
 export const searchValidation: TakoHandler = async (c, next) => {
-  if (!c.scriptArgs.positionals[0]) {
-    c.print({ message: 'Error: Missing required argument "query"', style: 'red', level: 'error' })
-    return
-  }
   const { limit } = c.scriptArgs.values as { limit?: string }
   if (limit) {
     const parsed = parseInt(limit, 10)
@@ -187,7 +185,7 @@ export const searchCommand: TakoHandler = async (c) => {
       })
     } else {
       // Remove highlighted title from JSON output
-      const jsonResults = results.map(({ ...result }) => result)
+      const jsonResults = results.map(({ highlightedTitle, ...result }) => result)
       c.print({
         message: JSON.stringify(
           {

--- a/src/commands/search/index.ts
+++ b/src/commands/search/index.ts
@@ -1,4 +1,4 @@
-import type { Command } from 'commander'
+import type { TakoArgs, TakoHandler } from '@takojs/tako'
 
 interface AlgoliaHit {
   title?: string
@@ -29,142 +29,179 @@ interface AlgoliaResponse {
   hits: AlgoliaHit[]
 }
 
-export function searchCommand(program: Command) {
-  program
-    .command('search')
-    .argument('<query>', 'Search query for Hono documentation')
-    .option('-l, --limit <number>', 'Number of results to show (default: 5)', (value) => {
-      const parsed = parseInt(value, 10)
-      if (isNaN(parsed) || parsed < 1 || parsed > 20) {
-        console.warn('Limit must be a number between 1 and 20\n')
-        return 5
-      }
-      return parsed
+export const searchArgs: TakoArgs = {
+  config: {
+    options: {
+      limit: {
+        type: 'string',
+        short: 'l',
+      },
+      pretty: {
+        type: 'boolean',
+        short: 'p',
+      },
+    },
+  },
+  metadata: {
+    help: 'Search Hono documentation',
+    options: {
+      limit: {
+        help: 'Number of results to show (default: 5)',
+        placeholder: '<number>',
+      },
+      pretty: {
+        help: 'Display results in human-readable format',
+      },
+    },
+  },
+}
+
+export const searchValidation: TakoHandler = (c, next) => {
+  if (!c.scriptArgs.positionals[0]) {
+    c.print({ message: 'Error: Missing required argument "query"', style: 'red', level: 'error' })
+    return
+  }
+  const { limit } = c.scriptArgs.values
+  if (limit) {
+    const parsed = parseInt(limit as string, 10)
+    if (isNaN(parsed) || parsed < 1 || parsed > 20) {
+      c.print({ message: 'Limit must be a number between 1 and 20\n', style: 'yellow', level: 'warn' })
+      c.scriptArgs.values.limit = 5
+    } else {
+      c.scriptArgs.values.limit = parsed
+    }
+  }
+  next()
+}
+
+export const searchCommand: TakoHandler = async (c) => {
+  const query = c.scriptArgs.positionals[0]
+  const { limit, pretty } = c.scriptArgs.values
+
+  // Search-only API key - safe to embed in public code
+  const ALGOLIA_APP_ID = '1GIFSU1REV'
+  const ALGOLIA_API_KEY = 'c6a0f86b9a9f8551654600f28317a9e9'
+  const ALGOLIA_INDEX = 'hono'
+
+  const searchUrl = `https://${ALGOLIA_APP_ID}-dsn.algolia.net/1/indexes/${ALGOLIA_INDEX}/query`
+
+  try {
+    if (pretty) {
+      c.print({ message: `Searching for "${query}"...` })
+    }
+
+    const response = await fetch(searchUrl, {
+      method: 'POST',
+      headers: {
+        'X-Algolia-API-Key': ALGOLIA_API_KEY,
+        'X-Algolia-Application-Id': ALGOLIA_APP_ID,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query,
+        hitsPerPage: (limit as number) || 5,
+      }),
     })
-    .option('-p, --pretty', 'Display results in human-readable format')
-    .description('Search Hono documentation')
-    .action(async (query: string, options: { limit?: number; pretty?: boolean }) => {
-      // Search-only API key - safe to embed in public code
-      const ALGOLIA_APP_ID = '1GIFSU1REV'
-      const ALGOLIA_API_KEY = 'c6a0f86b9a9f8551654600f28317a9e9'
-      const ALGOLIA_INDEX = 'hono'
 
-      const searchUrl = `https://${ALGOLIA_APP_ID}-dsn.algolia.net/1/indexes/${ALGOLIA_INDEX}/query`
+    if (!response.ok) {
+      throw new Error(`Search failed: ${response.status} ${response.statusText}`)
+    }
 
-      try {
-        if (options.pretty) {
-          console.log(`Searching for "${query}"...`)
+    const data: AlgoliaResponse = await response.json()
+
+    if (data.hits.length === 0) {
+      if (pretty) {
+        c.print({ message: '\nNo results found.' })
+      } else {
+        c.print({ message: JSON.stringify({ query, total: 0, results: [] }, null, 2) })
+      }
+      return
+    }
+
+    // Helper function to clean HTML tags completely
+    const cleanHighlight = (text: string) => text.replace(/<[^>]*>/g, '')
+
+    const results = data.hits.map((hit) => {
+      // Get title from various sources
+      let title = hit.title
+      let highlightedTitle = title
+      if (!title && hit._highlightResult?.hierarchy?.lvl1) {
+        title = cleanHighlight(hit._highlightResult.hierarchy.lvl1.value)
+        highlightedTitle = hit._highlightResult.hierarchy.lvl1.value
+      }
+      if (!title) {
+        title = hit.hierarchy?.lvl1 || hit.hierarchy?.lvl0 || 'Untitled'
+        highlightedTitle = title
+      }
+
+      // Build hierarchy path
+      const hierarchyParts: string[] = []
+      if (hit.hierarchy?.lvl0 && hit.hierarchy.lvl0 !== 'Documentation') {
+        hierarchyParts.push(hit.hierarchy.lvl0)
+      }
+      if (hit.hierarchy?.lvl1 && hit.hierarchy.lvl1 !== title) {
+        hierarchyParts.push(cleanHighlight(hit.hierarchy.lvl1))
+      }
+      if (hit.hierarchy?.lvl2) {
+        hierarchyParts.push(cleanHighlight(hit.hierarchy.lvl2))
+      }
+
+      const category = hierarchyParts.length > 0 ? hierarchyParts.join(' > ') : ''
+      const url = hit.url
+      const urlPath = new URL(url).pathname
+
+      return {
+        title,
+        highlightedTitle,
+        category,
+        url,
+        path: urlPath,
+      }
+    })
+
+    if (pretty) {
+      c.print({ message: `\nFound ${data.hits.length} results:\n` })
+
+      // Helper function to convert HTML highlights to terminal formatting
+      const formatHighlight = (text: string) => {
+        return text
+          .replace(/<span class="algolia-docsearch-suggestion--highlight">/g, '\x1b[33m') // Yellow
+          .replace(/<\/span>/g, '\x1b[0m') // Reset
+      }
+
+      results.forEach((result, index) => {
+        c.print({ message: `${index + 1}. ${formatHighlight(result.highlightedTitle || result.title)}` })
+        if (result.category) {
+          c.print({ message: `   Category: ${result.category}` })
         }
-
-        const response = await fetch(searchUrl, {
-          method: 'POST',
-          headers: {
-            'X-Algolia-API-Key': ALGOLIA_API_KEY,
-            'X-Algolia-Application-Id': ALGOLIA_APP_ID,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
+        c.print({ message: `   URL: ${result.url}` })
+        c.print({ message: `   Command: hono docs ${result.path}` })
+        c.print({ message: '' })
+      })
+    } else {
+      // Remove highlighted title from JSON output
+      const jsonResults = results.map(({ ...result }) => result)
+      c.print({
+        message: JSON.stringify(
+          {
             query,
-            hitsPerPage: options.limit || 5,
-          }),
-        })
-
-        if (!response.ok) {
-          throw new Error(`Search failed: ${response.status} ${response.statusText}`)
-        }
-
-        const data: AlgoliaResponse = await response.json()
-
-        if (data.hits.length === 0) {
-          if (options.pretty) {
-            console.log('\nNo results found.')
-          } else {
-            console.log(JSON.stringify({ query, total: 0, results: [] }, null, 2))
-          }
-          return
-        }
-
-        // Helper function to clean HTML tags completely
-        const cleanHighlight = (text: string) => text.replace(/<[^>]*>/g, '')
-
-        const results = data.hits.map((hit) => {
-          // Get title from various sources
-          let title = hit.title
-          let highlightedTitle = title
-          if (!title && hit._highlightResult?.hierarchy?.lvl1) {
-            title = cleanHighlight(hit._highlightResult.hierarchy.lvl1.value)
-            highlightedTitle = hit._highlightResult.hierarchy.lvl1.value
-          }
-          if (!title) {
-            title = hit.hierarchy?.lvl1 || hit.hierarchy?.lvl0 || 'Untitled'
-            highlightedTitle = title
-          }
-
-          // Build hierarchy path
-          const hierarchyParts: string[] = []
-          if (hit.hierarchy?.lvl0 && hit.hierarchy.lvl0 !== 'Documentation') {
-            hierarchyParts.push(hit.hierarchy.lvl0)
-          }
-          if (hit.hierarchy?.lvl1 && hit.hierarchy.lvl1 !== title) {
-            hierarchyParts.push(cleanHighlight(hit.hierarchy.lvl1))
-          }
-          if (hit.hierarchy?.lvl2) {
-            hierarchyParts.push(cleanHighlight(hit.hierarchy.lvl2))
-          }
-
-          const category = hierarchyParts.length > 0 ? hierarchyParts.join(' > ') : ''
-          const url = hit.url
-          const urlPath = new URL(url).pathname
-
-          return {
-            title,
-            highlightedTitle,
-            category,
-            url,
-            path: urlPath,
-          }
-        })
-
-        if (options.pretty) {
-          console.log(`\nFound ${data.hits.length} results:\n`)
-
-          // Helper function to convert HTML highlights to terminal formatting
-          const formatHighlight = (text: string) => {
-            return text
-              .replace(/<span class="algolia-docsearch-suggestion--highlight">/g, '\x1b[33m') // Yellow
-              .replace(/<\/span>/g, '\x1b[0m') // Reset
-          }
-
-          results.forEach((result, index) => {
-            console.log(`${index + 1}. ${formatHighlight(result.highlightedTitle || result.title)}`)
-            if (result.category) {
-              console.log(`   Category: ${result.category}`)
-            }
-            console.log(`   URL: ${result.url}`)
-            console.log(`   Command: hono docs ${result.path}`)
-            console.log('')
-          })
-        } else {
-          // Remove highlighted title from JSON output
-          const jsonResults = results.map(({ highlightedTitle, ...result }) => result)
-          console.log(
-            JSON.stringify(
-              {
-                query,
-                total: data.hits.length,
-                results: jsonResults,
-              },
-              null,
-              2
-            )
-          )
-        }
-      } catch (error) {
-        console.error(
-          'Error searching documentation:',
-          error instanceof Error ? error.message : String(error)
-        )
-        console.log('\nPlease visit: https://hono.dev/docs')
-      }
+            total: data.hits.length,
+            results: jsonResults,
+          },
+          null,
+          2
+        ),
+      })
+    }
+  } catch (error) {
+    c.print({
+      message: [
+        'Error searching documentation:',
+        error instanceof Error ? error.message : String(error),
+      ],
+      style: 'red',
+      level: 'error',
     })
+    c.print({ message: '\nPlease visit: https://hono.dev/docs' })
+  }
 }

--- a/src/commands/search/index.ts
+++ b/src/commands/search/index.ts
@@ -61,14 +61,14 @@ export const searchValidation: TakoHandler = (c, next) => {
     c.print({ message: 'Error: Missing required argument "query"', style: 'red', level: 'error' })
     return
   }
-  const { limit } = c.scriptArgs.values
+  const { limit } = c.scriptArgs.values as { limit?: string }
   if (limit) {
-    const parsed = parseInt(limit as string, 10)
+    const parsed = parseInt(limit, 10)
     if (isNaN(parsed) || parsed < 1 || parsed > 20) {
       c.print({ message: 'Limit must be a number between 1 and 20\n', style: 'yellow', level: 'warn' })
-      c.scriptArgs.values.limit = 5
+      c.args.values.limit = 5
     } else {
-      c.scriptArgs.values.limit = parsed
+      c.args.values.limit = parsed
     }
   }
   next()
@@ -76,7 +76,8 @@ export const searchValidation: TakoHandler = (c, next) => {
 
 export const searchCommand: TakoHandler = async (c) => {
   const query = c.scriptArgs.positionals[0]
-  const { limit, pretty } = c.scriptArgs.values
+  const { pretty } = c.scriptArgs.values
+  const { limit } = c.args.values as { limit?: number }
 
   // Search-only API key - safe to embed in public code
   const ALGOLIA_APP_ID = '1GIFSU1REV'
@@ -99,7 +100,7 @@ export const searchCommand: TakoHandler = async (c) => {
       },
       body: JSON.stringify({
         query,
-        hitsPerPage: (limit as number) || 5,
+        hitsPerPage: limit || 5,
       }),
     })
 

--- a/src/commands/search/index.ts
+++ b/src/commands/search/index.ts
@@ -56,7 +56,7 @@ export const searchArgs: TakoArgs = {
   },
 }
 
-export const searchValidation: TakoHandler = (c, next) => {
+export const searchValidation: TakoHandler = async (c, next) => {
   if (!c.scriptArgs.positionals[0]) {
     c.print({ message: 'Error: Missing required argument "query"', style: 'red', level: 'error' })
     return
@@ -65,13 +65,17 @@ export const searchValidation: TakoHandler = (c, next) => {
   if (limit) {
     const parsed = parseInt(limit, 10)
     if (isNaN(parsed) || parsed < 1 || parsed > 20) {
-      c.print({ message: 'Limit must be a number between 1 and 20\n', style: 'yellow', level: 'warn' })
+      c.print({
+        message: 'Limit must be a number between 1 and 20\n',
+        style: 'yellow',
+        level: 'warn',
+      })
       c.args.values.limit = 5
     } else {
       c.args.values.limit = parsed
     }
   }
-  next()
+  await next()
 }
 
 export const searchCommand: TakoHandler = async (c) => {
@@ -171,7 +175,9 @@ export const searchCommand: TakoHandler = async (c) => {
       }
 
       results.forEach((result, index) => {
-        c.print({ message: `${index + 1}. ${formatHighlight(result.highlightedTitle || result.title)}` })
+        c.print({
+          message: `${index + 1}. ${formatHighlight(result.highlightedTitle || result.title)}`,
+        })
         if (result.category) {
           c.print({ message: `   Category: ${result.category}` })
         }

--- a/src/commands/serve/index.test.ts
+++ b/src/commands/serve/index.test.ts
@@ -87,7 +87,6 @@ describe('serveCommand', () => {
     })
 
     await tako.cli({ config: { args: ['serve'] } })
-    await new Promise((resolve) => setTimeout(resolve, 50))
 
     // Verify serve was called with default port 7070
     expect(mockServe).toHaveBeenCalledWith(
@@ -106,7 +105,6 @@ describe('serveCommand', () => {
     })
 
     await tako.cli({ config: { args: ['serve', '-p', '8080'] } })
-    await new Promise((resolve) => setTimeout(resolve, 50))
 
     // Verify serve was called with custom port
     expect(mockServe).toHaveBeenCalledWith(
@@ -138,7 +136,6 @@ describe('serveCommand', () => {
     vi.doMock(absolutePath, () => ({ default: mockApp }))
 
     await tako.cli({ config: { args: ['serve', 'app.js'] } })
-    await new Promise((resolve) => setTimeout(resolve, 50))
 
     // Test the captured fetch function
     const rootRequest = new Request('http://localhost:7070/')
@@ -158,7 +155,6 @@ describe('serveCommand', () => {
     })
 
     await tako.cli({ config: { args: ['serve'] } })
-    await new Promise((resolve) => setTimeout(resolve, 50))
 
     // Test 404 behavior with default empty app
     const request = new Request('http://localhost:7070/non-existent')
@@ -168,7 +164,6 @@ describe('serveCommand', () => {
 
   it('should create default empty app when no entry argument provided', async () => {
     await tako.cli({ config: { args: ['serve'] } })
-    await new Promise((resolve) => setTimeout(resolve, 50))
 
     // Verify serve was called
     expect(mockServe).toHaveBeenCalledWith(
@@ -238,7 +233,6 @@ describe('serveCommand', () => {
         ],
       },
     })
-    await new Promise((resolve) => setTimeout(resolve, 50))
 
     // Test without auth - should get 401
     const unauthorizedRequest = new Request('http://localhost:7070/shops')

--- a/src/commands/serve/index.ts
+++ b/src/commands/serve/index.ts
@@ -71,9 +71,10 @@ export const serveCommand: TakoHandler = async (c) => {
       app = new Hono()
     } else {
       const appFilePath = realpathSync(appPath)
-      app = await buildAndImportApp(appFilePath, {
+      const buildIterator = buildAndImportApp(appFilePath, {
         external: ['@hono/node-server'],
       })
+      app = (await buildIterator.next()).value
     }
   }
 

--- a/src/commands/serve/index.ts
+++ b/src/commands/serve/index.ts
@@ -34,6 +34,7 @@ export const serveArgs: TakoArgs = {
   },
   metadata: {
     help: 'Start server',
+    placeholder: '[entry]',
     options: {
       port: {
         help: 'port number',

--- a/src/commands/serve/index.ts
+++ b/src/commands/serve/index.ts
@@ -50,8 +50,8 @@ export const serveArgs: TakoArgs = {
   },
 }
 
-export const serveValidation: TakoHandler = (_c, next) => {
-  next()
+export const serveValidation: TakoHandler = async (_c, next) => {
+  await next()
 }
 
 export const serveCommand: TakoHandler = async (c) => {

--- a/src/commands/serve/index.ts
+++ b/src/commands/serve/index.ts
@@ -1,10 +1,11 @@
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
-import type { Command } from 'commander'
+import type { TakoArgs, TakoHandler } from '@takojs/tako'
 import { Hono } from 'hono'
 import { showRoutes } from 'hono/dev'
 import { existsSync, realpathSync } from 'node:fs'
 import { resolve } from 'node:path'
+import * as process from 'node:process'
 import { buildAndImportApp } from '../../utils/build.js'
 import { builtinMap } from './builtin-map.js'
 
@@ -15,91 +16,110 @@ import { builtinMap } from './builtin-map.js'
   }
 })
 
-export function serveCommand(program: Command) {
-  program
-    .command('serve')
-    .description('Start server')
-    .argument('[entry]', 'entry file')
-    .option('-p, --port <port>', 'port number')
-    .option('--show-routes', 'show registered routes')
-    .option(
-      '--use <middleware>',
-      'use middleware',
-      (value, previous: string[]) => {
-        return previous ? [...previous, value] : [value]
+export const serveArgs: TakoArgs = {
+  config: {
+    options: {
+      port: {
+        type: 'string',
+        short: 'p',
       },
-      []
-    )
-    .action(
-      async (
-        entry: string | undefined,
-        options: { port?: string; showRoutes?: boolean; use?: string[] }
-      ) => {
-        let app: Hono
+      'show-routes': {
+        type: 'boolean',
+      },
+      use: {
+        type: 'string',
+        multiple: true,
+      },
+    },
+  },
+  metadata: {
+    help: 'Start server',
+    options: {
+      port: {
+        help: 'port number',
+        placeholder: '<port>',
+      },
+      'show-routes': {
+        help: 'show registered routes',
+      },
+      use: {
+        help: 'use middleware',
+        placeholder: '<middleware>',
+      },
+    },
+  },
+}
 
-        if (!entry) {
-          // Create a default Hono app if no entry is provided
-          app = new Hono()
-        } else {
-          const appPath = resolve(process.cwd(), entry)
+export const serveValidation: TakoHandler = (_c, next) => {
+  next()
+}
 
-          if (!existsSync(appPath)) {
-            // Create a default Hono app if entry file doesn't exist
-            app = new Hono()
-          } else {
-            const appFilePath = realpathSync(appPath)
-            app = await buildAndImportApp(appFilePath, {
-              external: ['@hono/node-server'],
-            })
-          }
+export const serveCommand: TakoHandler = async (c) => {
+  const entry = c.scriptArgs.positionals[0]
+  const { port, 'show-routes': showRoutesOption, use: useOptions } = c.scriptArgs.values
+  let app: Hono
+
+  if (!entry) {
+    // Create a default Hono app if no entry is provided
+    app = new Hono()
+  } else {
+    const appPath = resolve(process.cwd(), entry)
+
+    if (!existsSync(appPath)) {
+      // Create a default Hono app if entry file doesn't exist
+      app = new Hono()
+    } else {
+      const appFilePath = realpathSync(appPath)
+      app = await buildAndImportApp(appFilePath, {
+        external: ['@hono/node-server'],
+      })
+    }
+  }
+
+  // Import all builtin functions from the builtin map
+  const allFunctions: Record<string, any> = {}
+  const uniqueModules = [...new Set(Object.values(builtinMap))]
+
+  for (const modulePath of uniqueModules) {
+    try {
+      const module = await import(modulePath)
+      // Add all exported functions from this module
+      for (const [funcName, modulePathInMap] of Object.entries(builtinMap)) {
+        if (modulePathInMap === modulePath && module[funcName]) {
+          allFunctions[funcName] = module[funcName]
         }
-
-        // Import all builtin functions from the builtin map
-        const allFunctions: Record<string, any> = {}
-        const uniqueModules = [...new Set(Object.values(builtinMap))]
-
-        for (const modulePath of uniqueModules) {
-          try {
-            const module = await import(modulePath)
-            // Add all exported functions from this module
-            for (const [funcName, modulePathInMap] of Object.entries(builtinMap)) {
-              if (modulePathInMap === modulePath && module[funcName]) {
-                allFunctions[funcName] = module[funcName]
-              }
-            }
-          } catch (error) {
-            // Skip modules that can't be imported (optional dependencies)
-          }
-        }
-
-        const baseApp = new Hono()
-        // Apply middleware from --use options
-        for (const use of options.use || []) {
-          // Create function with all available functions in scope
-          const functionNames = Object.keys(allFunctions)
-          const functionValues = Object.values(allFunctions)
-          const func = new Function('c', 'next', ...functionNames, `return (${use})`)
-          baseApp.use(async (c, next) => {
-            const middleware = func(c, next, ...functionValues)
-            return typeof middleware === 'function' ? middleware(c, next) : middleware
-          })
-        }
-
-        baseApp.route('/', app)
-
-        if (options.showRoutes) {
-          showRoutes(baseApp)
-        }
-
-        serve(
-          {
-            fetch: baseApp.fetch,
-            port: options.port ? Number.parseInt(options.port) : 7070,
-          },
-          (info) => {
-            console.log(`Listening on http://localhost:${info.port}`)
-          }
-        )
       }
-    )
+    } catch {
+      // Skip modules that can't be imported (optional dependencies)
+    }
+  }
+
+  const baseApp = new Hono()
+  // Apply middleware from --use options
+  for (const use of (useOptions as string[] | undefined) || []) {
+    // Create function with all available functions in scope
+    const functionNames = Object.keys(allFunctions)
+    const functionValues = Object.values(allFunctions)
+    const func = new Function('c', 'next', ...functionNames, `return (${use})`)
+    baseApp.use(async (c, next) => {
+      const middleware = func(c, next, ...functionValues)
+      return typeof middleware === 'function' ? middleware(c, next) : middleware
+    })
+  }
+
+  baseApp.route('/', app)
+
+  if (showRoutesOption) {
+    showRoutes(baseApp)
+  }
+
+  serve(
+    {
+      fetch: baseApp.fetch,
+      port: port ? Number.parseInt(port as string) : 7070,
+    },
+    (info) => {
+      c.print({ message: `Listening on http://localhost:${info.port}` })
+    }
+  )
 }

--- a/src/utils/build.test.ts
+++ b/src/utils/build.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Buffer } from 'node:buffer'
 
 // Mock dependencies
 vi.mock('esbuild', () => ({

--- a/src/utils/build.ts
+++ b/src/utils/build.ts
@@ -1,7 +1,6 @@
 import * as esbuild from 'esbuild'
+import type { Hono } from 'hono'
 import { Buffer } from 'node:buffer'
-import { extname } from 'node:path'
-import { pathToFileURL } from 'node:url'
 
 export interface BuildOptions {
   external?: string[]

--- a/src/utils/build.ts
+++ b/src/utils/build.ts
@@ -1,4 +1,5 @@
 import * as esbuild from 'esbuild'
+import { Buffer } from 'node:buffer'
 import { extname } from 'node:path'
 import { pathToFileURL } from 'node:url'
 


### PR DESCRIPTION
Last Modified: 2025-11-26

Hello Hono contributors,

This PR replaces `commander` with `@takojs/tako`.

https://takojs.github.io/

Although Issue #42 was already closed, this change addresses the original problem.
As yusukebe said:

> It will be a good idea to create a library that supports multiple runtimes, not only Node.js, outside of github.com/honojs. If so, we can use it in this honojs/cli.

As a result of this work, the CLI now uses `@takojs/tako`.

<details>
<summary>Terminal commands used during migration</summary>

```bash
$ bun remove commander
$ bun add @takojs/tako
```

```bash
$ bun run build
$ tsup
CLI Building entry: src/cli.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.0
CLI Using tsup config: /workspaces/cli/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
ESM dist/cli.js 22.83 KB
ESM ⚡️ Build success in 73ms
$ publint
Running publint v0.3.14 for @hono/cli...
Packing files with `bun pack`...
Linting...
All good!

$ bun dist/cli.js -g docs
Usage: hono [OPTIONS] COMMAND [ARGS]...

  CLI for Hono

Options:
  -g, --gen docs  Generate documentation.
  -h, --help      Show help.
  -v, --version   Show version.

Commands:
  docs      Display Hono documentation
  optimize  Build optimized Hono class
  request   Send request to Hono app using app.request()
  search    Search Hono documentation
  serve     Start server

Usage: hono docs [OPTIONS] [path]

  Display Hono documentation

Options:
  -g, --gen docs  Generate documentation.
  -h, --help      Show help.
  -v, --version   Show version.

Usage: hono optimize [OPTIONS] [entry]

  Build optimized Hono class

Options:
  -g, --gen docs           Generate documentation.
  -h, --help               Show help.
  -v, --version            Show version.
  -o, --outfile <outfile>  output file (default: "dist/index.js")
  -m, --minify             minify output file

Usage: hono request [OPTIONS] [file]

  Send request to Hono app using app.request()

Options:
  -g, --gen docs         Generate documentation.
  -h, --help             Show help.
  -v, --version          Show version.
  -P, --path <path>      Request path (default: "/")
  -X, --method <method>  HTTP method (default: "GET")
  -d, --data <data>      Request body data
  -H, --header <header>  Custom headers
  -w, --watch            Watch for changes and resend request (default: false)

Usage: hono search [OPTIONS] <query>

  Search Hono documentation (positionals required)

Options:
  -g, --gen docs        Generate documentation.
  -h, --help            Show help.
  -v, --version         Show version.
  -l, --limit <number>  Number of results to show (default: 5)
  -p, --pretty          Display results in human-readable format

Usage: hono serve [OPTIONS] [entry]

  Start server

Options:
  -g, --gen docs          Generate documentation.
  -h, --help              Show help.
  -v, --version           Show version.
  -p, --port <port>       port number
      --show-routes       show registered routes
      --use <middleware>  use middleware

$ bunx @hono/cli@0.1.0
Usage: hono [options] [command]

CLI for Hono

Options:
  -v, --version               display version number
  -h, --help                  display help for command

Commands:
  docs [path]                 Display Hono documentation
  optimize [options] [entry]  Build optimized Hono class
  search [options] <query>    Search Hono documentation
  request [options] [file]    Send request to Hono app using app.request()
  serve [options] [entry]     Start server
  help [command]              display help for command
```

</details>