### PR TITLE
chore: resolve lint warning

### DIFF
--- a/src/commands/docs/index.test.ts
+++ b/src/commands/docs/index.test.ts
@@ -33,6 +33,7 @@ describe('docsCommand', () => {
     if (originalIsTTY !== undefined) {
       process.stdin.isTTY = originalIsTTY
     } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (process.stdin as any).isTTY
     }
   })

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -21,7 +21,9 @@ import { requestCommand } from './index.js'
 describe('requestCommand', () => {
   let program: Command
   let consoleLogSpy: ReturnType<typeof vi.spyOn>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockModules: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockBuildAndImportApp: any
 
   const createBuildIterator = (app: Hono) => {

--- a/src/commands/search/index.ts
+++ b/src/commands/search/index.ts
@@ -149,6 +149,7 @@ export function searchCommand(program: Command) {
           })
         } else {
           // Remove highlighted title from JSON output
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const jsonResults = results.map(({ highlightedTitle, ...result }) => result)
           console.log(
             JSON.stringify(

--- a/src/commands/serve/index.test.ts
+++ b/src/commands/serve/index.test.ts
@@ -29,10 +29,11 @@ import { serveCommand } from './index.js'
 
 describe('serveCommand', () => {
   let program: Command
-  let mockEsbuild: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockModules: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockServe: any
-  let mockShowRoutes: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let capturedFetchFunction: any
 
   beforeEach(async () => {
@@ -40,7 +41,6 @@ describe('serveCommand', () => {
     serveCommand(program)
 
     mockServe = vi.mocked((await import('@hono/node-server')).serve)
-    mockShowRoutes = vi.mocked((await import('hono/dev')).showRoutes)
 
     mockModules = {
       existsSync: vi.fn(),
@@ -48,6 +48,7 @@ describe('serveCommand', () => {
     }
 
     // Capture the fetch function passed to serve
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockServe.mockImplementation((options: any, callback?: any) => {
       capturedFetchFunction = options.fetch
       if (callback) {
@@ -181,6 +182,7 @@ export default app
   it('should handle typical use case: basicAuth + proxy to ramen-api.dev', async () => {
     // Mock basicAuth middleware
     const mockBasicAuth = vi.fn().mockImplementation(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return async (c: any, next: any) => {
         const auth = c.req.header('Authorization')
         if (!auth || auth !== 'Basic aG9ubzpob25v') {

--- a/src/commands/serve/index.test.ts
+++ b/src/commands/serve/index.test.ts
@@ -42,6 +42,11 @@ describe('serveCommand', () => {
     mockServe = vi.mocked((await import('@hono/node-server')).serve)
     mockShowRoutes = vi.mocked((await import('hono/dev')).showRoutes)
 
+    mockModules = {
+      existsSync: vi.fn(),
+      resolve: vi.fn(),
+    }
+
     // Capture the fetch function passed to serve
     mockServe.mockImplementation((options: any, callback?: any) => {
       capturedFetchFunction = options.fetch

--- a/src/commands/serve/index.ts
+++ b/src/commands/serve/index.ts
@@ -62,6 +62,7 @@ export function serveCommand(program: Command) {
         }
 
         // Import all builtin functions from the builtin map
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const allFunctions: Record<string, any> = {}
         const uniqueModules = [...new Set(Object.values(builtinMap))]
 
@@ -74,7 +75,7 @@ export function serveCommand(program: Command) {
                 allFunctions[funcName] = module[funcName]
               }
             }
-          } catch (error) {
+          } catch {
             // Skip modules that can't be imported (optional dependencies)
           }
         }

--- a/src/utils/build.test.ts
+++ b/src/utils/build.test.ts
@@ -14,13 +14,17 @@ vi.mock('node:url', () => ({
 import { buildAndImportApp } from './build.js'
 
 describe('buildAndImportApp', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockEsbuildDispose: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockEsbuild: any
 
   const setupBundledCode = (code: string) => {
     mockEsbuild.mockImplementation((param: Parameters<typeof context>[0]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let onEnd: (result: any) => void
       param.plugins?.[0].setup({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         onEnd: (cb: (result: any) => void) => {
           onEnd = cb
         },


### PR DESCRIPTION
- delete unused vars
- add `eslint-disable-next-line @typescript-eslint/no-explicit-any`

### before

```
./hono/cli/src/commands/docs/index.test.ts
  36:32  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

./hono/cli/src/commands/request/index.test.ts
  24:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  25:30  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

./hono/cli/src/commands/search/index.ts
  152:46  warning  'highlightedTitle' is defined but never used  @typescript-eslint/no-unused-vars

./hono/cli/src/commands/serve/index.test.ts
   32:7   warning  'mockEsbuild' is defined but never used              @typescript-eslint/no-unused-vars
   32:20  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   33:20  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   34:18  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   35:7   warning  'mockShowRoutes' is assigned a value but never used  @typescript-eslint/no-unused-vars
   35:23  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   36:30  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   46:44  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   46:60  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  179:24  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  179:35  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any

./hono/cli/src/commands/serve/index.ts
  65:44  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  77:20  warning  'error' is defined but never used         @typescript-eslint/no-unused-vars

./hono/cli/src/utils/build.test.ts
  17:27  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  18:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  22:27  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  24:30  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

### after

no warning.

