### PR TITLE
ci: run CI on the next branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    branches: [main]
+    branches: [main, next]
 
 permissions:
   contents: read


### PR DESCRIPTION
Run CI on pushes and PRs for the `next` branch. We will develop 0.2 (#77) there and merge it to `main` when it is ready.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code