### PR TITLE
test(serve): extend timeout of the server test

### DIFF
--- a/src/commands/serve/index.test.ts
+++ b/src/commands/serve/index.test.ts
@@ -149,7 +149,7 @@ export default app
     const apiResponse = await capturedFetchFunction(apiRequest)
     const apiData = await apiResponse.json()
     expect(apiData).toEqual({ message: 'API response' })
-  })
+  }, 30000)
 
   it('should return 404 for non-existent routes when no app file exists', async () => {
     await program.parseAsync(['node', 'test', 'serve'])


### PR DESCRIPTION
This test runs `npm install`, so the default 5s timeout is not enough on slow CI runners. It made CI flaky (e.g. the Node 24 job on #82). Set it to 30s.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code