### PR TITLE
feat: add routes command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,16 @@ hono request
 
 # Build your Hono app
 hono build
+
+# Show routes of your Hono app
+hono routes
 ```
 
 ## Commands
 
 - `request [file]` - Send request to Hono app using `app.request()`
 - `build [entry]` - Build your Hono app
+- `routes [file]` - Show routes of your Hono app
 
 ### `request`
 
@@ -179,6 +183,39 @@ The result is JSON. All Hono CLI commands use the same envelope: `ok` and `data`
 ```
 
 Use `--plain` for a human-readable format.
+
+### `routes`
+
+Show all routes of your Hono app, like [`showRoutes()`](https://hono.dev/docs/helpers/dev#showroutes).
+
+```bash
+hono routes [file] [options]
+```
+
+**Arguments:**
+
+- `file` - Path to the Hono app file (TypeScript/JSX supported, optional)
+
+**Options:**
+
+- `--verbose` - include middleware
+- `--plain` - human-readable output instead of JSON
+- `-e, --external <package>` - Mark package as external (can be used multiple times)
+
+**Output:**
+
+```json
+{
+  "ok": true,
+  "data": {
+    "router": "SmartRouter + RegExpRouter",
+    "routes": [
+      { "method": "GET", "path": "/", "name": "[handler]", "isMiddleware": false },
+      { "method": "POST", "path": "/posts", "name": "[handler]", "isMiddleware": false }
+    ]
+  }
+}
+```
 
 ## Tips
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { buildCommand } from './commands/build/index.js'
 import { requestCommand } from './commands/request/index.js'
+import { routesCommand } from './commands/routes/index.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -21,5 +22,6 @@ program
 // Register commands
 buildCommand(program)
 requestCommand(program)
+routesCommand(program)
 
 program.parse()

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -1,12 +1,8 @@
 import type { Command } from 'commander'
 import type { Hono } from 'hono'
-import { existsSync, realpathSync } from 'node:fs'
-import { resolve } from 'node:path'
-import { buildAndImportApp } from '../../utils/build.js'
 import { getFilenameFromPath, saveFile } from '../../utils/file.js'
-import { CliError, handleErrors, printResult } from '../../utils/output.js'
-
-const DEFAULT_ENTRY_CANDIDATES = ['src/index.ts', 'src/index.tsx', 'src/index.js', 'src/index.jsx']
+import { getBuildIterator } from '../../utils/load-app.js'
+import { handleErrors, printResult } from '../../utils/output.js'
 
 interface RequestOptions {
   method?: string
@@ -135,43 +131,6 @@ const handleSaveOutput = async (
     console.error(`Error saving file: ${error instanceof Error ? error.message : String(error)}`)
     return undefined
   }
-}
-
-export function getBuildIterator(
-  appPath: string | undefined,
-  watch: boolean,
-  external: string[] = []
-): AsyncGenerator<Hono> {
-  // Determine entry file path
-  let entry: string
-  let resolvedAppPath: string
-
-  if (appPath) {
-    // If appPath is provided, use it as-is (could be relative or absolute)
-    entry = appPath
-    resolvedAppPath = resolve(process.cwd(), entry)
-  } else {
-    // Use default candidates
-    entry =
-      DEFAULT_ENTRY_CANDIDATES.find((candidate) => existsSync(resolve(process.cwd(), candidate))) ??
-      DEFAULT_ENTRY_CANDIDATES[0]
-    resolvedAppPath = resolve(process.cwd(), entry)
-  }
-
-  if (!existsSync(resolvedAppPath)) {
-    throw new CliError(
-      'ENTRY_NOT_FOUND',
-      `Entry file ${entry} does not exist`,
-      'Pass an existing app file: hono request src/index.ts'
-    )
-  }
-
-  const appFilePath = realpathSync(resolvedAppPath)
-  return buildAndImportApp(appFilePath, {
-    external: ['@hono/node-server', ...external],
-    watch,
-    sourcemap: true,
-  })
 }
 
 export async function executeRequest(

--- a/src/commands/routes/index.test.ts
+++ b/src/commands/routes/index.test.ts
@@ -1,0 +1,155 @@
+import { Command } from 'commander'
+import { Hono } from 'hono'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock dependencies
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  realpathSync: vi.fn(),
+}))
+
+vi.mock('node:path', () => ({
+  resolve: vi.fn(),
+}))
+
+vi.mock('../../utils/build.js', () => ({
+  buildAndImportApp: vi.fn(),
+}))
+
+import { routesCommand } from './index.js'
+
+describe('routesCommand', () => {
+  let program: Command
+  const spyOnConsole = (method: 'log' | 'warn' | 'error') =>
+    vi.spyOn(console, method).mockImplementation(() => {})
+  let consoleLogSpy: ReturnType<typeof spyOnConsole>
+
+  const getMockModules = async () => ({
+    existsSync: vi.mocked((await import('node:fs')).existsSync),
+    realpathSync: vi.mocked((await import('node:fs')).realpathSync),
+    resolve: vi.mocked((await import('node:path')).resolve),
+  })
+  const getMockBuildAndImportApp = async () =>
+    vi.mocked((await import('../../utils/build.js')).buildAndImportApp)
+
+  let mockModules: Awaited<ReturnType<typeof getMockModules>>
+  let mockBuildAndImportApp: Awaited<ReturnType<typeof getMockBuildAndImportApp>>
+
+  async function* createBuildIterator(app: Hono): AsyncGenerator<Hono> {
+    yield app
+  }
+
+  const setupBasicMocks = (mockApp: Hono) => {
+    mockModules.existsSync.mockReturnValue(true)
+    mockModules.realpathSync.mockReturnValue('test-app.js')
+    mockModules.resolve.mockImplementation((cwd: string, path: string) => {
+      return `${cwd}/${path}`
+    })
+    mockBuildAndImportApp.mockReturnValue(createBuildIterator(mockApp))
+  }
+
+  beforeEach(async () => {
+    program = new Command()
+    routesCommand(program)
+    consoleLogSpy = spyOnConsole('log')
+
+    mockModules = await getMockModules()
+    mockBuildAndImportApp = await getMockBuildAndImportApp()
+
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore()
+    vi.restoreAllMocks()
+  })
+
+  it('should list routes as the JSON envelope', async () => {
+    const app = new Hono()
+    app.get('/', (c) => c.text('Hello'))
+    app.post('/posts', (c) => c.json({ ok: true }))
+    setupBasicMocks(app)
+
+    await program.parseAsync(['node', 'test', 'routes', 'test-app.js'])
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(parsed.ok).toBe(true)
+    expect(typeof parsed.data.router).toBe('string')
+    expect(parsed.data.routes).toEqual([
+      { method: 'GET', path: '/', name: '[handler]', isMiddleware: false },
+      { method: 'POST', path: '/posts', name: '[handler]', isMiddleware: false },
+    ])
+  })
+
+  it('should exclude middleware by default', async () => {
+    const app = new Hono()
+    app.use(async (_c, next) => {
+      await next()
+    })
+    app.get('/', (c) => c.text('Hello'))
+    setupBasicMocks(app)
+
+    await program.parseAsync(['node', 'test', 'routes', 'test-app.js'])
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(parsed.data.routes).toEqual([
+      { method: 'GET', path: '/', name: '[handler]', isMiddleware: false },
+    ])
+  })
+
+  it('should include middleware with --verbose', async () => {
+    const app = new Hono()
+    app.use(async (_c, next) => {
+      await next()
+    })
+    app.get('/', (c) => c.text('Hello'))
+    setupBasicMocks(app)
+
+    await program.parseAsync(['node', 'test', 'routes', '--verbose', 'test-app.js'])
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(parsed.data.routes).toEqual([
+      { method: 'ALL', path: '/*', name: '[middleware]', isMiddleware: true },
+      { method: 'GET', path: '/', name: '[handler]', isMiddleware: false },
+    ])
+  })
+
+  it('should print routes as text with --plain', async () => {
+    const app = new Hono()
+    app.get('/', (c) => c.text('Hello'))
+    app.delete('/posts/:id', (c) => c.json({ ok: true }))
+    setupBasicMocks(app)
+
+    await program.parseAsync(['node', 'test', 'routes', '--plain', 'test-app.js'])
+
+    expect(consoleLogSpy).toHaveBeenNthCalledWith(1, 'GET    /')
+    expect(consoleLogSpy).toHaveBeenNthCalledWith(2, 'DELETE /posts/:id')
+  })
+
+  it('should print a JSON error when the entry file is not found', async () => {
+    mockModules.existsSync.mockReturnValue(false)
+    mockModules.resolve.mockImplementation((cwd: string, path: string) => `${cwd}/${path}`)
+
+    await program.parseAsync(['node', 'test', 'routes', 'missing.ts'])
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(parsed.ok).toBe(false)
+    expect(parsed.error.code).toBe('ENTRY_NOT_FOUND')
+    expect(process.exitCode).toBe(1)
+    process.exitCode = undefined
+  })
+
+  it('should print a JSON error when the app does not expose routes', async () => {
+    const app = new Hono()
+    Reflect.set(app, 'routes', undefined)
+    setupBasicMocks(app)
+
+    await program.parseAsync(['node', 'test', 'routes', 'test-app.js'])
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(parsed.ok).toBe(false)
+    expect(parsed.error.code).toBe('INVALID_APP')
+    expect(process.exitCode).toBe(1)
+    process.exitCode = undefined
+  })
+})

--- a/src/commands/routes/index.ts
+++ b/src/commands/routes/index.ts
@@ -1,0 +1,56 @@
+import type { Command } from 'commander'
+import { getRouterName, inspectRoutes } from 'hono/dev'
+import { getBuildIterator } from '../../utils/load-app.js'
+import { CliError, handleErrors, printResult } from '../../utils/output.js'
+
+interface RoutesOptions {
+  verbose: boolean
+  plain: boolean
+  external?: string[]
+}
+
+export function routesCommand(program: Command) {
+  program
+    .command('routes')
+    .description('Show routes of your Hono app')
+    .argument('[file]', 'Path to the Hono app file')
+    .option('--verbose', 'include middleware', false)
+    .option('--plain', 'human-readable output instead of JSON', false)
+    .option(
+      '-e, --external <package>',
+      'Mark package as external (can be used multiple times)',
+      (value: string, previous: string[]) => {
+        return previous ? [...previous, value] : [value]
+      },
+      [] as string[]
+    )
+    .action(
+      handleErrors(async (file: string | undefined, options: RoutesOptions) => {
+        const buildIterator = getBuildIterator(file, false, options.external || [])
+        const app = (await buildIterator.next()).value
+
+        if (!app || !Array.isArray(app.routes)) {
+          throw new CliError(
+            'INVALID_APP',
+            'The app does not expose routes',
+            'Export the Hono instance as the default export'
+          )
+        }
+
+        const routes = inspectRoutes(app).filter(
+          ({ isMiddleware }) => options.verbose || !isMiddleware
+        )
+        const router = getRouterName(app)
+
+        if (options.plain) {
+          const maxMethodLength = Math.max(...routes.map(({ method }) => method.length), 0)
+          for (const route of routes) {
+            console.log(`${route.method.padEnd(maxMethodLength)} ${route.path}`)
+          }
+          return
+        }
+
+        printResult({ router, routes })
+      })
+    )
+}

--- a/src/utils/load-app.ts
+++ b/src/utils/load-app.ts
@@ -1,0 +1,46 @@
+import type { Hono } from 'hono'
+import { existsSync, realpathSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { buildAndImportApp } from './build.js'
+import { CliError } from './output.js'
+
+const DEFAULT_ENTRY_CANDIDATES = ['src/index.ts', 'src/index.tsx', 'src/index.js', 'src/index.jsx']
+
+/**
+ * Resolve the entry file and return an iterator of the built app.
+ */
+export function getBuildIterator(
+  appPath: string | undefined,
+  watch: boolean,
+  external: string[] = []
+): AsyncGenerator<Hono> {
+  let entry: string
+  let resolvedAppPath: string
+
+  if (appPath) {
+    // If appPath is provided, use it as-is (could be relative or absolute)
+    entry = appPath
+    resolvedAppPath = resolve(process.cwd(), entry)
+  } else {
+    // Use default candidates
+    entry =
+      DEFAULT_ENTRY_CANDIDATES.find((candidate) => existsSync(resolve(process.cwd(), candidate))) ??
+      DEFAULT_ENTRY_CANDIDATES[0]
+    resolvedAppPath = resolve(process.cwd(), entry)
+  }
+
+  if (!existsSync(resolvedAppPath)) {
+    throw new CliError(
+      'ENTRY_NOT_FOUND',
+      `Entry file ${entry} does not exist`,
+      'Pass an existing app file: hono request src/index.ts'
+    )
+  }
+
+  const appFilePath = realpathSync(resolvedAppPath)
+  return buildAndImportApp(appFilePath, {
+    external: ['@hono/node-server', ...external],
+    watch,
+    sourcemap: true,
+  })
+}


### PR DESCRIPTION
Add `hono routes` (part of #77). It loads the app and shows all routes with `inspectRoutes()` from `hono/dev`, so the output matches `showRoutes()`.

- Output is the shared JSON envelope: `{ router, routes: [{ method, path, name, isMiddleware }] }`
- Middleware is excluded by default. `--verbose` includes it, `--plain` prints `showRoutes()`-style text
- Moved the entry resolution from `request` to `src/utils/load-app.ts` and shared it

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code