### PR TITLE
docs: delegate Hono docs to the skill and hono.dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,12 @@ Rank findings by severity: `blocker` / `bug` / `risk` / `nit`.
 
 ## Hono Documentation
 
-Need Hono details? Fetch <https://hono.dev/llms.txt> or a page under
-`https://hono.dev/docs/...`.
+Need Hono details? Fetch a page under `https://hono.dev/docs/...` with
+the `Accept: text/markdown` header to get Markdown.
+
+```bash
+curl -H 'Accept: text/markdown' https://hono.dev/docs/routing
+```
 
 ## Maintaining This File
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,9 @@ Rank findings by severity: `blocker` / `bug` / `risk` / `nit`.
 
 ## Hono Documentation
 
-Need Hono details? Fetch a page under `https://hono.dev/docs/...` with
-the `Accept: text/markdown` header to get Markdown.
+Need Hono details? Fetch <https://hono.dev/llms.txt> to find the right
+page, then fetch the page with the `Accept: text/markdown` header to
+get Markdown.
 
 ```bash
 curl -H 'Accept: text/markdown' https://hono.dev/docs/routing

--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ hono agent-context
 
 ### Using Hono CLI with AI Code Agents
 
-Add one line to your project's `AGENTS.md` or `CLAUDE.md`:
+Use the [Hono skill](https://github.com/yusukebe/hono-skill). It teaches the agent when and how to use Hono CLI, together with Hono best practices.
+
+Without the skill, add one line to your project's `AGENTS.md` or `CLAUDE.md`:
 
 ```markdown
 Working on this Hono app? Run `hono agent-context` first and follow it.
 ```
-
-The agent reads the output and learns the whole workflow: `routes` to see the app, `request` to test it, and `build` to bundle it.
 
 ## Authors
 

--- a/src/commands/agent-context/document.ts
+++ b/src/commands/agent-context/document.ts
@@ -73,8 +73,9 @@ export const renderAgentContext = (program: Command): string =>
     section(
       2,
       'Hono documentation',
-      'This document covers the CLI only. For Hono framework details, fetch a page ' +
-        'under `https://hono.dev/docs/...` with the `Accept: text/markdown` header:',
+      'This document covers the CLI only. For Hono framework details, fetch ' +
+        '`https://hono.dev/llms.txt` to find the right page, then fetch the page ' +
+        'with the `Accept: text/markdown` header:',
       codeBlock('bash', ["curl -H 'Accept: text/markdown' https://hono.dev/docs/routing"])
     ),
     section(

--- a/src/commands/agent-context/document.ts
+++ b/src/commands/agent-context/document.ts
@@ -72,6 +72,13 @@ export const renderAgentContext = (program: Command): string =>
     ),
     section(
       2,
+      'Hono documentation',
+      'This document covers the CLI only. For Hono framework details, fetch a page ' +
+        'under `https://hono.dev/docs/...` with the `Accept: text/markdown` header:',
+      codeBlock('bash', ["curl -H 'Accept: text/markdown' https://hono.dev/docs/routing"])
+    ),
+    section(
+      2,
       'Commands',
       ...program.commands
         .filter((command) => command.name() !== 'agent-context')

--- a/src/commands/agent-context/index.test.ts
+++ b/src/commands/agent-context/index.test.ts
@@ -37,6 +37,12 @@ describe('agentContextCommand', () => {
     expect(output).toContain('## Recommended workflow')
   })
 
+  it('should delegate framework details to hono.dev', async () => {
+    const output = await getOutput()
+    expect(output).toContain('## Hono documentation')
+    expect(output).toContain('Accept: text/markdown')
+  })
+
   it('should document every command except itself', async () => {
     const output = await getOutput()
     expect(output).toContain('### hono build [entry]')


### PR DESCRIPTION
The CLI should not carry Hono documentation itself. Delegate it:

- README points agents to the [Hono skill](https://github.com/yusukebe/hono-skill) (soon official) as the main integration
- `agent-context` and AGENTS.md now say: for framework details, fetch `hono.dev/docs/...` with the `Accept: text/markdown` header. hono.dev returns clean Markdown (verified)

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code