### PR TITLE
feat: add ssg command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ hono build
 # Show routes of your Hono app
 hono routes
 
+# Generate static files from your Hono app
+hono ssg
+
 # Show how to use Hono CLI, for coding agents
 hono agent-context
 ```
@@ -34,6 +37,7 @@ hono agent-context
 - `request [file]` - Send request to Hono app using `app.request()`
 - `build [entry]` - Build your Hono app
 - `routes [file]` - Show routes of your Hono app
+- `ssg [file]` - Generate static files from your Hono app
 - `agent-context` - Show how to use Hono CLI, for coding agents
 
 ### `request`
@@ -218,6 +222,38 @@ hono routes [file] [options]
   }
 }
 ```
+
+### `ssg`
+
+Generate static files from your Hono app with the [SSG Helper](https://hono.dev/docs/helpers/ssg).
+
+```bash
+hono ssg [file] [options]
+```
+
+**Arguments:**
+
+- `file` - Path to the Hono app file (TypeScript/JSX supported, optional)
+
+**Options:**
+
+- `-o, --outdir <dir>` - output directory (default: `static`)
+- `--plain` - human-readable output instead of JSON
+- `-e, --external <package>` - Mark package as external (can be used multiple times)
+
+**Output:**
+
+```json
+{
+  "ok": true,
+  "data": {
+    "output": "static",
+    "files": ["static/index.html", "static/about.html"]
+  }
+}
+```
+
+Only GET routes are generated. Use `ssgParams()` for dynamic routes and `disableSSG()` to skip a route.
 
 ### `agent-context`
 

--- a/README.md
+++ b/README.md
@@ -253,8 +253,6 @@ hono ssg [file] [options]
 }
 ```
 
-Only GET routes are generated. Use `ssgParams()` for dynamic routes and `disableSSG()` to skip a route.
-
 ### `agent-context`
 
 Show how to use Hono CLI, as Markdown for coding agents. The content is generated from the command definitions, so it always matches the installed version.

--- a/README.md
+++ b/README.md
@@ -238,8 +238,20 @@ hono ssg [file] [options]
 **Options:**
 
 - `-o, --outdir <dir>` - output directory (default: `static`)
+- `--include <path>` - generate only matching paths, `*` matches anything (can be used multiple times)
+- `--exclude <path>` - skip matching paths, `*` matches anything (can be used multiple times)
 - `--plain` - human-readable output instead of JSON
 - `-e, --external <package>` - Mark package as external (can be used multiple times)
+
+**Examples:**
+
+```bash
+# Generate everything to static/
+hono ssg
+
+# Skip API routes
+hono ssg --exclude '/api/*'
+```
 
 **Output:**
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { agentContextCommand } from './commands/agent-context/index.js'
 import { buildCommand } from './commands/build/index.js'
 import { requestCommand } from './commands/request/index.js'
 import { routesCommand } from './commands/routes/index.js'
+import { ssgCommand } from './commands/ssg/index.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -24,6 +25,7 @@ program
 buildCommand(program)
 requestCommand(program)
 routesCommand(program)
+ssgCommand(program)
 agentContextCommand(program)
 
 program.parse()

--- a/src/commands/agent-context/document.ts
+++ b/src/commands/agent-context/document.ts
@@ -4,11 +4,13 @@ import { bullets, codeBlock, section, steps } from '../../utils/markdown.js'
 import { agentContext as buildContext } from '../build/index.js'
 import { agentContext as requestContext } from '../request/index.js'
 import { agentContext as routesContext } from '../routes/index.js'
+import { agentContext as ssgContext } from '../ssg/index.js'
 
 const contexts: Record<string, CommandAgentContext> = {
   routes: routesContext,
   request: requestContext,
   build: buildContext,
+  ssg: ssgContext,
 }
 
 const commandDoc = (command: Command, context?: CommandAgentContext): string => {

--- a/src/commands/ssg/index.test.ts
+++ b/src/commands/ssg/index.test.ts
@@ -1,0 +1,140 @@
+import { Command } from 'commander'
+import { Hono } from 'hono'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock dependencies
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  realpathSync: vi.fn(),
+}))
+
+vi.mock('node:path', () => ({
+  resolve: vi.fn(),
+}))
+
+vi.mock('../../utils/build.js', () => ({
+  buildAndImportApp: vi.fn(),
+}))
+
+vi.mock('hono/ssg', () => ({
+  toSSG: vi.fn(),
+}))
+
+import { ssgCommand } from './index.js'
+
+describe('ssgCommand', () => {
+  let program: Command
+  const spyOnLog = () => vi.spyOn(console, 'log').mockImplementation(() => {})
+  let consoleLogSpy: ReturnType<typeof spyOnLog>
+
+  const getMockModules = async () => ({
+    existsSync: vi.mocked((await import('node:fs')).existsSync),
+    realpathSync: vi.mocked((await import('node:fs')).realpathSync),
+    resolve: vi.mocked((await import('node:path')).resolve),
+  })
+  const getMockBuildAndImportApp = async () =>
+    vi.mocked((await import('../../utils/build.js')).buildAndImportApp)
+  const getMockToSSG = async () => vi.mocked((await import('hono/ssg')).toSSG)
+
+  let mockModules: Awaited<ReturnType<typeof getMockModules>>
+  let mockBuildAndImportApp: Awaited<ReturnType<typeof getMockBuildAndImportApp>>
+  let mockToSSG: Awaited<ReturnType<typeof getMockToSSG>>
+
+  async function* createBuildIterator(app: Hono): AsyncGenerator<Hono> {
+    yield app
+  }
+
+  const app = new Hono()
+
+  const setupBasicMocks = () => {
+    mockModules.existsSync.mockReturnValue(true)
+    mockModules.realpathSync.mockReturnValue('test-app.js')
+    mockModules.resolve.mockImplementation((cwd: string, path: string) => {
+      return `${cwd}/${path}`
+    })
+    mockBuildAndImportApp.mockReturnValue(createBuildIterator(app))
+  }
+
+  beforeEach(async () => {
+    program = new Command()
+    ssgCommand(program)
+    consoleLogSpy = spyOnLog()
+
+    mockModules = await getMockModules()
+    mockBuildAndImportApp = await getMockBuildAndImportApp()
+    mockToSSG = await getMockToSSG()
+
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore()
+    vi.restoreAllMocks()
+  })
+
+  it('should generate static files and print the JSON envelope', async () => {
+    setupBasicMocks()
+    mockToSSG.mockResolvedValue({
+      success: true,
+      files: ['static/index.html', 'static/about.html'],
+    })
+
+    await program.parseAsync(['node', 'test', 'ssg', 'test-app.js'])
+
+    const fsPromises = (await import('node:fs/promises')).default
+    expect(mockToSSG).toHaveBeenCalledWith(app, fsPromises, { dir: 'static' })
+    expect(JSON.parse(consoleLogSpy.mock.calls[0][0])).toEqual({
+      ok: true,
+      data: {
+        output: 'static',
+        files: ['static/index.html', 'static/about.html'],
+      },
+    })
+  })
+
+  it('should pass the output directory from -o', async () => {
+    setupBasicMocks()
+    mockToSSG.mockResolvedValue({ success: true, files: [] })
+
+    await program.parseAsync(['node', 'test', 'ssg', '-o', 'dist/static', 'test-app.js'])
+
+    const fsPromises = (await import('node:fs/promises')).default
+    expect(mockToSSG).toHaveBeenCalledWith(app, fsPromises, { dir: 'dist/static' })
+  })
+
+  it('should print file names with --plain', async () => {
+    setupBasicMocks()
+    mockToSSG.mockResolvedValue({ success: true, files: ['static/index.html'] })
+
+    await program.parseAsync(['node', 'test', 'ssg', '--plain', 'test-app.js'])
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('static/index.html')
+  })
+
+  it('should print a JSON error when toSSG fails', async () => {
+    setupBasicMocks()
+    mockToSSG.mockResolvedValue({ success: false, files: [], error: new Error('boom') })
+
+    await program.parseAsync(['node', 'test', 'ssg', 'test-app.js'])
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(parsed.ok).toBe(false)
+    expect(parsed.error.code).toBe('SSG_FAILED')
+    expect(parsed.error.message).toBe('boom')
+    expect(process.exitCode).toBe(1)
+    process.exitCode = undefined
+  })
+
+  it('should print a JSON error when the entry file is not found', async () => {
+    mockModules.existsSync.mockReturnValue(false)
+    mockModules.resolve.mockImplementation((cwd: string, path: string) => `${cwd}/${path}`)
+
+    await program.parseAsync(['node', 'test', 'ssg', 'missing.ts'])
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(parsed.ok).toBe(false)
+    expect(parsed.error.code).toBe('ENTRY_NOT_FOUND')
+    expect(process.exitCode).toBe(1)
+    process.exitCode = undefined
+  })
+})

--- a/src/commands/ssg/index.test.ts
+++ b/src/commands/ssg/index.test.ts
@@ -82,7 +82,11 @@ describe('ssgCommand', () => {
     await program.parseAsync(['node', 'test', 'ssg', 'test-app.js'])
 
     const fsPromises = (await import('node:fs/promises')).default
-    expect(mockToSSG).toHaveBeenCalledWith(app, fsPromises, { dir: 'static' })
+    expect(mockToSSG).toHaveBeenCalledWith(
+      app,
+      fsPromises,
+      expect.objectContaining({ dir: 'static' })
+    )
     expect(JSON.parse(consoleLogSpy.mock.calls[0][0])).toEqual({
       ok: true,
       data: {
@@ -99,7 +103,28 @@ describe('ssgCommand', () => {
     await program.parseAsync(['node', 'test', 'ssg', '-o', 'dist/static', 'test-app.js'])
 
     const fsPromises = (await import('node:fs/promises')).default
-    expect(mockToSSG).toHaveBeenCalledWith(app, fsPromises, { dir: 'dist/static' })
+    expect(mockToSSG).toHaveBeenCalledWith(
+      app,
+      fsPromises,
+      expect.objectContaining({ dir: 'dist/static' })
+    )
+  })
+
+  it('should skip excluded paths via beforeRequestHook', async () => {
+    setupBasicMocks()
+    mockToSSG.mockResolvedValue({ success: true, files: [] })
+
+    await program.parseAsync(['node', 'test', 'ssg', '--exclude', '/api/*', 'test-app.js'])
+
+    const options = mockToSSG.mock.calls[0][2]
+    const hook = options?.beforeRequestHook
+    if (typeof hook !== 'function') {
+      throw new Error('beforeRequestHook must be a function')
+    }
+    const kept = new Request('http://localhost/about')
+    const skipped = new Request('http://localhost/api/data')
+    expect(await hook(kept)).toBe(kept)
+    expect(await hook(skipped)).toBe(false)
   })
 
   it('should print file names with --plain', async () => {

--- a/src/commands/ssg/index.ts
+++ b/src/commands/ssg/index.ts
@@ -1,0 +1,65 @@
+import type { Command } from 'commander'
+import { toSSG } from 'hono/ssg'
+import fs from 'node:fs/promises'
+import type { CommandAgentContext } from '../../utils/agent-context.js'
+import { getBuildIterator } from '../../utils/load-app.js'
+import { CliError, handleErrors, printResult } from '../../utils/output.js'
+
+export const agentContext: CommandAgentContext = {
+  output: '{ "output": "static", "files": ["static/index.html", "static/about.html"] }',
+  errors: ['ENTRY_NOT_FOUND', 'SSG_FAILED'],
+  examples: ['hono ssg', 'hono ssg -o dist/static src/app.ts'],
+  notes: [
+    'Only GET routes are generated. Use `ssgParams()` for dynamic routes and `disableSSG()` to skip a route.',
+  ],
+}
+
+interface SsgOptions {
+  outdir: string
+  plain: boolean
+  external?: string[]
+}
+
+export function ssgCommand(program: Command) {
+  program
+    .command('ssg')
+    .description('Generate static files from your Hono app')
+    .argument('[file]', 'Path to the Hono app file')
+    .option('-o, --outdir <dir>', 'output directory', 'static')
+    .option('--plain', 'human-readable output instead of JSON', false)
+    .option(
+      '-e, --external <package>',
+      'Mark package as external (can be used multiple times)',
+      (value: string, previous: string[]) => {
+        return previous ? [...previous, value] : [value]
+      },
+      [] as string[]
+    )
+    .action(
+      handleErrors(async (file: string | undefined, options: SsgOptions) => {
+        const buildIterator = getBuildIterator(file, false, options.external || [])
+        const app = (await buildIterator.next()).value
+
+        const result = await toSSG(app, fs, { dir: options.outdir })
+
+        if (!result.success) {
+          throw new CliError(
+            'SSG_FAILED',
+            result.error?.message ?? 'Failed to generate static files',
+            'Check the routes with: hono routes'
+          )
+        }
+
+        const files = result.files ?? []
+
+        if (options.plain) {
+          for (const generated of files) {
+            console.log(generated)
+          }
+          return
+        }
+
+        printResult({ output: options.outdir, files })
+      })
+    )
+}

--- a/src/commands/ssg/index.ts
+++ b/src/commands/ssg/index.ts
@@ -9,9 +9,6 @@ export const agentContext: CommandAgentContext = {
   output: '{ "output": "static", "files": ["static/index.html", "static/about.html"] }',
   errors: ['ENTRY_NOT_FOUND', 'SSG_FAILED'],
   examples: ['hono ssg', 'hono ssg -o dist/static src/app.ts'],
-  notes: [
-    'Only GET routes are generated. Use `ssgParams()` for dynamic routes and `disableSSG()` to skip a route.',
-  ],
 }
 
 interface SsgOptions {

--- a/src/commands/ssg/index.ts
+++ b/src/commands/ssg/index.ts
@@ -4,18 +4,25 @@ import fs from 'node:fs/promises'
 import type { CommandAgentContext } from '../../utils/agent-context.js'
 import { getBuildIterator } from '../../utils/load-app.js'
 import { CliError, handleErrors, printResult } from '../../utils/output.js'
+import { createRouteFilter } from './route-filter.js'
 
 export const agentContext: CommandAgentContext = {
   output: '{ "output": "static", "files": ["static/index.html", "static/about.html"] }',
   errors: ['ENTRY_NOT_FOUND', 'SSG_FAILED'],
-  examples: ['hono ssg', 'hono ssg -o dist/static src/app.ts'],
+  examples: ['hono ssg', 'hono ssg -o dist/static src/app.ts', "hono ssg --exclude '/api/*'"],
+  notes: ['`--include` / `--exclude` select routes by path. `*` matches anything.'],
 }
 
 interface SsgOptions {
   outdir: string
   plain: boolean
+  include: string[]
+  exclude: string[]
   external?: string[]
 }
+
+const collect = (value: string, previous: string[]): string[] =>
+  previous ? [...previous, value] : [value]
 
 export function ssgCommand(program: Command) {
   program
@@ -25,11 +32,21 @@ export function ssgCommand(program: Command) {
     .option('-o, --outdir <dir>', 'output directory', 'static')
     .option('--plain', 'human-readable output instead of JSON', false)
     .option(
+      '--include <path>',
+      'generate only matching paths, `*` matches anything (can be used multiple times)',
+      collect,
+      [] as string[]
+    )
+    .option(
+      '--exclude <path>',
+      'skip matching paths, `*` matches anything (can be used multiple times)',
+      collect,
+      [] as string[]
+    )
+    .option(
       '-e, --external <package>',
       'Mark package as external (can be used multiple times)',
-      (value: string, previous: string[]) => {
-        return previous ? [...previous, value] : [value]
-      },
+      collect,
       [] as string[]
     )
     .action(
@@ -37,7 +54,11 @@ export function ssgCommand(program: Command) {
         const buildIterator = getBuildIterator(file, false, options.external || [])
         const app = (await buildIterator.next()).value
 
-        const result = await toSSG(app, fs, { dir: options.outdir })
+        const filter = createRouteFilter(options.include, options.exclude)
+        const result = await toSSG(app, fs, {
+          dir: options.outdir,
+          beforeRequestHook: (req) => (filter(new URL(req.url).pathname) ? req : false),
+        })
 
         if (!result.success) {
           throw new CliError(

--- a/src/commands/ssg/route-filter.test.ts
+++ b/src/commands/ssg/route-filter.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { createRouteFilter } from './route-filter'
+
+describe('createRouteFilter', () => {
+  it('should pass everything with no patterns', () => {
+    const filter = createRouteFilter([], [])
+    expect(filter('/')).toBe(true)
+    expect(filter('/about')).toBe(true)
+  })
+
+  it('should exclude matching paths', () => {
+    const filter = createRouteFilter([], ['/api/*'])
+    expect(filter('/')).toBe(true)
+    expect(filter('/api/data')).toBe(false)
+    expect(filter('/api')).toBe(true)
+  })
+
+  it('should only pass included paths', () => {
+    const filter = createRouteFilter(['/blog/*'], [])
+    expect(filter('/blog/hello')).toBe(true)
+    expect(filter('/about')).toBe(false)
+  })
+
+  it('should apply exclude after include', () => {
+    const filter = createRouteFilter(['/blog/*'], ['/blog/draft-*'])
+    expect(filter('/blog/hello')).toBe(true)
+    expect(filter('/blog/draft-1')).toBe(false)
+  })
+
+  it('should not treat regex characters as special', () => {
+    const filter = createRouteFilter([], ['/a.b'])
+    expect(filter('/a.b')).toBe(false)
+    expect(filter('/axb')).toBe(true)
+  })
+})

--- a/src/commands/ssg/route-filter.ts
+++ b/src/commands/ssg/route-filter.ts
@@ -1,0 +1,21 @@
+// Path patterns for --include / --exclude. `*` matches anything.
+
+const toRegExp = (pattern: string): RegExp => {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')
+  return new RegExp(`^${escaped}$`)
+}
+
+export const createRouteFilter = (
+  include: string[],
+  exclude: string[]
+): ((pathname: string) => boolean) => {
+  const includeRegExps = include.map(toRegExp)
+  const excludeRegExps = exclude.map(toRegExp)
+
+  return (pathname) => {
+    if (includeRegExps.length > 0 && !includeRegExps.some((r) => r.test(pathname))) {
+      return false
+    }
+    return !excludeRegExps.some((r) => r.test(pathname))
+  }
+}


### PR DESCRIPTION
Add `hono ssg` (part of #77). It loads the app and generates static files with `toSSG()` from `hono/ssg`.

- Output is the shared JSON envelope: `{ output, files }`
- `-o, --outdir` sets the output directory (default: `static`)
- `--include` / `--exclude` select routes by path (`*` matches anything), so you can skip routes without touching the app code. Implemented with `toSSG`'s `beforeRequestHook`
- A `toSSG` failure becomes an `SSG_FAILED` JSON error

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code