### PR TITLE
feat: make the CLI discoverable for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ It's not a `create-*` command and not a Vite wrapper. It loads your Hono app dir
 
 ## Installation
 
+Install it in your project. Coding agents find it in `package.json`:
+
+```bash
+npm install -D @hono/cli
+```
+
+Or globally:
+
 ```bash
 npm install -g @hono/cli
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ program
   .name('hono')
   .description('CLI for Hono')
   .version(packageJson.version, '-v, --version', 'display version number')
+  .addHelpText('after', "\nFor coding agents: run 'hono agent-context' and follow it.")
 
 // Register commands
 buildCommand(program)


### PR DESCRIPTION
Two small changes so a coding agent can find Hono CLI on its own:

- `hono --help` now ends with: run `hono agent-context` and follow it. Any agent that touches the binary gets routed to the full document
- The README recommends `npm install -D @hono/cli` first. A local install leaves a trace in `package.json`, which agents always read. Global install is now the secondary option

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code