### PR TITLE
feat(request): add --trace to show matched routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ hono request [file] [options]
 - `-o, --output <file>` - Write response body to file instead of stdout
 - `-O, --remote-name` - Write response body to file named as remote file
 - `--plain` - human-readable output instead of JSON
+- `--trace` - include matched routes in the output
 - `-i, --include` - Include status and headers in the output (with `--plain`)
 - `-I, --head` - Show only status and headers in the output (with `--plain`)
 - `-e, --external <package>` - Mark package as external (can be used multiple times)
@@ -103,6 +104,32 @@ cat payload.json | hono request -P /api/users -X POST -d @-
 
 # Read the app code from stdin: `app` is predefined and exported for you
 echo 'app.get("/hello", (c) => c.json({ ok: true }))' | hono request - -P /hello
+
+# Debug an unexpected response: which middleware and handler matched?
+hono request -P /api/users/123 --trace
+```
+
+With `--trace`, the output has `matchedRoutes`. `responded` marks the route that returned the response:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "status": 200,
+    "headers": { "content-type": "application/json" },
+    "body": { "id": "123" },
+    "matchedRoutes": [
+      { "method": "ALL", "path": "/*", "name": "auth", "isMiddleware": true },
+      {
+        "method": "GET",
+        "path": "/api/users/:id",
+        "name": "getUser",
+        "isMiddleware": false,
+        "responded": true
+      }
+    ]
+  }
+}
 ```
 
 **Output:**

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -1063,4 +1063,50 @@ describe('requestCommand', () => {
       process.exitCode = undefined
     })
   })
+
+  describe('trace', () => {
+    it('should include matchedRoutes with --trace', async () => {
+      const mockApp = new Hono()
+      mockApp.use(async function auth(_c, next) {
+        await next()
+      })
+      mockApp.get('/api/users/:id', function getUser(c) {
+        return c.json({ id: c.req.param('id') })
+      })
+      setupBasicMocks('test-app.js', mockApp)
+
+      await program.parseAsync([
+        'node',
+        'test',
+        'request',
+        '-P',
+        '/api/users/123',
+        '--trace',
+        'test-app.js',
+      ])
+
+      const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+      expect(parsed.data.body).toEqual({ id: '123' })
+      expect(parsed.data.matchedRoutes).toEqual([
+        { method: 'ALL', path: '/*', name: 'auth', isMiddleware: true },
+        {
+          method: 'GET',
+          path: '/api/users/:id',
+          name: 'getUser',
+          isMiddleware: false,
+          responded: true,
+        },
+      ])
+    })
+
+    it('should reject --trace with --plain', async () => {
+      await program.parseAsync(['node', 'test', 'request', '--trace', '--plain', 'test-app.js'])
+
+      const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+      expect(parsed.ok).toBe(false)
+      expect(parsed.error.code).toBe('INVALID_OPTION')
+      expect(process.exitCode).toBe(1)
+      process.exitCode = undefined
+    })
+  })
 })

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -5,6 +5,7 @@ import type { CommandAgentContext } from '../../utils/agent-context.js'
 import { getFilenameFromPath, saveFile } from '../../utils/file.js'
 import { getBuildIterator, readStdin } from '../../utils/load-app.js'
 import { CliError, handleErrors, printResult } from '../../utils/output.js'
+import { withTracer } from './trace.js'
 
 export const agentContext: CommandAgentContext = {
   output:
@@ -14,12 +15,14 @@ export const agentContext: CommandAgentContext = {
     'hono request -P /api/users',
     `hono request -P /api/users -X POST -d '{"name":"Alice"}'`,
     'cat payload.json | hono request -P /api/users -X POST -d @-',
+    'hono request -P /api/users/123 --trace',
     `echo 'app.get("/hello", (c) => c.json({ ok: true }))' | hono request - -P /hello`,
   ],
   notes: [
     'No server needed. The request goes directly to app.request().',
     'Pass - as the file to read the app code from stdin. `app` is predefined and exported for you — write only routes. Code with its own `export default` is used as-is.',
     '-d @file reads the body from a file, -d @- reads it from stdin.',
+    '--trace adds matchedRoutes to the output: which middleware and handler matched, and which one responded. Use it to debug an unexpected response.',
     'A JSON response body is embedded as an object. A binary body becomes null with "binary": true — save it with -o.',
   ],
 }
@@ -31,6 +34,7 @@ interface RequestOptions {
   path?: string
   watch: boolean
   plain: boolean
+  trace: boolean
   output?: string
   remoteName: boolean
   include: boolean
@@ -58,6 +62,7 @@ export function requestCommand(program: Command) {
     .option('-o, --output <file>', 'Write response body to file instead of stdout')
     .option('-O, --remote-name', 'Write response body to file named as remote file', false)
     .option('--plain', 'human-readable output instead of JSON', false)
+    .option('--trace', 'include matched routes in the output', false)
     .option('-i, --include', 'Include protocol and headers in the output (with --plain)', false)
     .option('-I, --head', 'Show only protocol and headers in the output (with --plain)', false)
     .option(
@@ -74,6 +79,11 @@ export function requestCommand(program: Command) {
         const path = options.path || '/'
         const watch = options.watch
         const external = options.external || []
+        if (options.trace && options.plain) {
+          throw new CliError('INVALID_OPTION', 'Cannot use --trace with --plain', {
+            suggestions: ['Drop --plain. The trace is part of the JSON output'],
+          })
+        }
         if (file === '-' && options.data === '@-') {
           throw new CliError('INVALID_OPTION', 'Cannot read both the app and the body from stdin', {
             suggestions: ['Pass the app as a file, or the body with -d @file'],
@@ -82,7 +92,8 @@ export function requestCommand(program: Command) {
         options.data = resolveData(options.data)
         const buildIterator = getBuildIterator(file, watch, external)
         for await (const app of buildIterator) {
-          const result = await executeRequest(app, path, options)
+          const traced = options.trace ? withTracer(app) : undefined
+          const result = await executeRequest(traced?.app ?? app, path, options)
           const contentType = result.headers['content-type']
           const buffer = await result.response.clone().arrayBuffer()
           const isBinaryData = isBinaryResponse(buffer)
@@ -103,6 +114,7 @@ export function requestCommand(program: Command) {
             body: isBinaryData ? null : parseBody(result.body, contentType),
             ...(isBinaryData ? { binary: true } : {}),
             ...(savedTo ? { savedTo } : {}),
+            ...(traced ? { matchedRoutes: traced.getTrace() } : {}),
           })
         }
       })

--- a/src/commands/request/trace.test.ts
+++ b/src/commands/request/trace.test.ts
@@ -30,8 +30,11 @@ describe('withTracer', () => {
 
   it('should mark a middleware that responded', async () => {
     const app = new Hono()
-    app.use(async function guard(c) {
-      return c.text('blocked', 403)
+    app.use(async function guard(c, next) {
+      if (!c.req.header('authorization')) {
+        return c.text('blocked', 403)
+      }
+      await next()
     })
     app.get('/y', (c) => c.text('y'))
 

--- a/src/commands/request/trace.test.ts
+++ b/src/commands/request/trace.test.ts
@@ -1,0 +1,66 @@
+import { Hono } from 'hono'
+import { describe, it, expect } from 'vitest'
+import { withTracer } from './trace'
+
+describe('withTracer', () => {
+  it('should mark the handler that responded', async () => {
+    const app = new Hono()
+    app.use(async function auth(_c, next) {
+      await next()
+    })
+    app.get('/api/users/:id', function getUser(c) {
+      return c.json({ id: c.req.param('id') })
+    })
+
+    const { app: traced, getTrace } = withTracer(app)
+    const res = await traced.request('http://localhost/api/users/123')
+
+    expect(res.status).toBe(200)
+    expect(getTrace()).toEqual([
+      { method: 'ALL', path: '/*', name: 'auth', isMiddleware: true },
+      {
+        method: 'GET',
+        path: '/api/users/:id',
+        name: 'getUser',
+        isMiddleware: false,
+        responded: true,
+      },
+    ])
+  })
+
+  it('should mark a middleware that responded', async () => {
+    const app = new Hono()
+    app.use(async function guard(c, _next) {
+      return c.text('blocked', 403)
+    })
+    app.get('/y', (c) => c.text('y'))
+
+    const { app: traced, getTrace } = withTracer(app)
+    const res = await traced.request('http://localhost/y')
+
+    expect(res.status).toBe(403)
+    expect(getTrace()).toEqual([
+      { method: 'ALL', path: '/*', name: 'guard', isMiddleware: true, responded: true },
+      { method: 'GET', path: '/y', name: '[handler]', isMiddleware: false },
+    ])
+  })
+
+  it('should not mark anything on a not-found fallthrough', async () => {
+    const app = new Hono()
+    app.use(async function auth(_c, next) {
+      await next()
+    })
+    app.get('/x', (c) => c.text('x'))
+
+    const { app: traced, getTrace } = withTracer(app)
+    const res = await traced.request('http://localhost/nope')
+
+    expect(res.status).toBe(404)
+    expect(getTrace()).toEqual([{ method: 'ALL', path: '/*', name: 'auth', isMiddleware: true }])
+  })
+
+  it('should return an empty trace before any request', () => {
+    const { getTrace } = withTracer(new Hono())
+    expect(getTrace()).toEqual([])
+  })
+})

--- a/src/commands/request/trace.test.ts
+++ b/src/commands/request/trace.test.ts
@@ -30,7 +30,7 @@ describe('withTracer', () => {
 
   it('should mark a middleware that responded', async () => {
     const app = new Hono()
-    app.use(async function guard(c, _next) {
+    app.use(async function guard(c) {
       return c.text('blocked', 403)
     })
     app.get('/y', (c) => c.text('y'))

--- a/src/commands/request/trace.ts
+++ b/src/commands/request/trace.ts
@@ -1,0 +1,59 @@
+import { Hono } from 'hono'
+import type { MiddlewareHandler } from 'hono'
+import type { RouterRoute } from 'hono/types'
+import { findTargetHandler, isMiddleware } from 'hono/utils/handler'
+
+export interface TraceEntry {
+  method: string
+  path: string
+  name: string
+  isMiddleware: boolean
+  responded?: boolean
+}
+
+interface Matched {
+  routes: RouterRoute[]
+  index: number
+  status: number
+}
+
+/**
+ * Wrap the app with a tracer middleware. `getTrace()` returns the
+ * routes matched by the last request, with `responded` on the route
+ * that returned the response.
+ */
+export const withTracer = (app: Hono): { app: Hono; getTrace: () => TraceEntry[] } => {
+  let matched: Matched | undefined
+  const tracer: MiddlewareHandler = async (c, next) => {
+    await next()
+    matched = { routes: c.req.matchedRoutes, index: c.req.routeIndex, status: c.res.status }
+  }
+  const wrapper = new Hono()
+  wrapper.use(tracer)
+  wrapper.route('/', app)
+  return { app: wrapper, getTrace: () => formatTrace(matched, tracer) }
+}
+
+const formatTrace = (matched: Matched | undefined, tracer: MiddlewareHandler): TraceEntry[] => {
+  if (!matched) {
+    return []
+  }
+  return matched.routes
+    .map((route, index) => {
+      const target = findTargetHandler(route.handler)
+      const middleware = isMiddleware(target)
+      // A 404 response comes from the notFound handler, which is not in
+      // matchedRoutes. routeIndex then points at the last middleware, so
+      // do not mark it as responded.
+      const responded = index === matched.index && !(middleware && matched.status === 404)
+      return { route, target, middleware, responded }
+    })
+    .filter(({ route }) => route.handler !== tracer)
+    .map(({ route, target, middleware, responded }) => ({
+      method: route.method,
+      path: route.path,
+      name: target.name || (middleware ? '[middleware]' : '[handler]'),
+      isMiddleware: middleware,
+      ...(responded ? { responded: true } : {}),
+    }))
+}


### PR DESCRIPTION
Add `--trace` to `hono request` (idea from Yusuke). The output gets `matchedRoutes`: every middleware and handler that matched the request, with `responded` on the one that returned the response. Use it to debug an unexpected response in one command.

Implementation: wrap the app with a tracer middleware and read `c.req.matchedRoutes` / `c.req.routeIndex` — Hono's own APIs for this. On a 404 fallthrough the response comes from the notFound handler, so nothing is marked as responded then.

```bash
hono request -P /api/users/123 --trace
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code