### PR TITLE
feat(request): add --runtime to run the app on bun or deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ hono request [file] [options]
 - `-O, --remote-name` - Write response body to file named as remote file
 - `--plain` - human-readable output instead of JSON
 - `--trace` - include matched routes in the output
+- `--runtime <runtime>` - runtime to execute the app: `node` (default), `bun`, or `deno`
 - `-i, --include` - Include status and headers in the output (with `--plain`)
 - `-I, --head` - Show only status and headers in the output (with `--plain`)
 - `-e, --external <package>` - Mark package as external (can be used multiple times)
@@ -107,6 +108,10 @@ echo 'app.get("/hello", (c) => c.json({ ok: true }))' | hono request - -P /hello
 
 # Debug an unexpected response: which middleware and handler matched?
 hono request -P /api/users/123 --trace
+
+# Run the app on another runtime (it must be installed)
+hono request -P / --runtime bun
+hono request -P / --runtime deno
 ```
 
 With `--trace`, the output has `matchedRoutes`. `responded` marks the route that returned the response:

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { Hono } from 'hono'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type * as RuntimeModule from './runtime.js'
 
 // Mock dependencies
 vi.mock('node:fs', () => ({
@@ -15,7 +16,13 @@ vi.mock('node:path', () => ({
 
 vi.mock('../../utils/build.js', () => ({
   buildAndImportApp: vi.fn(),
+  buildAppBundle: vi.fn(),
 }))
+
+vi.mock('./runtime.js', async (importOriginal) => {
+  const original = await importOriginal<typeof RuntimeModule>()
+  return { ...original, runInRuntime: vi.fn() }
+})
 
 import { requestCommand } from './index.js'
 
@@ -1106,6 +1113,75 @@ describe('requestCommand', () => {
       expect(parsed.ok).toBe(false)
       expect(parsed.error.code).toBe('INVALID_OPTION')
       expect(process.exitCode).toBe(1)
+      process.exitCode = undefined
+    })
+  })
+
+  describe('runtime', () => {
+    const getMocks = async () => ({
+      buildAppBundle: vi.mocked((await import('../../utils/build.js')).buildAppBundle),
+      runInRuntime: vi.mocked((await import('./runtime.js')).runInRuntime),
+    })
+
+    it('should run the app on the selected runtime', async () => {
+      const { buildAppBundle, runInRuntime } = await getMocks()
+      mockModules.existsSync.mockReturnValue(true)
+      mockModules.realpathSync.mockReturnValue('test-app.js')
+      mockModules.resolve.mockImplementation((cwd: string, path: string) => `${cwd}/${path}`)
+      buildAppBundle.mockResolvedValue('bundled code')
+      runInRuntime.mockResolvedValue({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        bodyBase64: Buffer.from('{"hi":true}').toString('base64'),
+      })
+
+      await program.parseAsync([
+        'node',
+        'test',
+        'request',
+        '-P',
+        '/api',
+        '-H',
+        'X-Key: abc',
+        '--runtime',
+        'bun',
+        'test-app.js',
+      ])
+
+      expect(buildAppBundle).toHaveBeenCalledWith('test-app.js', [])
+      expect(runInRuntime).toHaveBeenCalledWith('bun', 'bundled code', {
+        path: '/api',
+        method: 'GET',
+        headers: { 'X-Key': 'abc' },
+      })
+      const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+      expect(parsed).toEqual({
+        ok: true,
+        data: {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body: { hi: true },
+          runtime: 'bun',
+        },
+      })
+    })
+
+    it('should reject an unknown runtime', async () => {
+      await program.parseAsync(['node', 'test', 'request', '--runtime', 'php', 'test-app.js'])
+
+      const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+      expect(parsed.ok).toBe(false)
+      expect(parsed.error.code).toBe('INVALID_OPTION')
+      expect(process.exitCode).toBe(1)
+      process.exitCode = undefined
+    })
+
+    it('should reject --runtime bun with --watch or --trace', async () => {
+      await program.parseAsync(['node', 'test', 'request', '--runtime', 'bun', '-w', 'a.ts'])
+      expect(JSON.parse(consoleLogSpy.mock.calls[0][0]).error.code).toBe('INVALID_OPTION')
+
+      await program.parseAsync(['node', 'test', 'request', '--runtime', 'deno', '--trace', 'a.ts'])
+      expect(JSON.parse(consoleLogSpy.mock.calls[1][0]).error.code).toBe('INVALID_OPTION')
       process.exitCode = undefined
     })
   })

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -16,7 +16,6 @@ vi.mock('node:path', () => ({
 
 vi.mock('../../utils/build.js', () => ({
   buildAndImportApp: vi.fn(),
-  buildAppBundle: vi.fn(),
 }))
 
 vi.mock('./runtime.js', async (importOriginal) => {
@@ -1119,16 +1118,14 @@ describe('requestCommand', () => {
 
   describe('runtime', () => {
     const getMocks = async () => ({
-      buildAppBundle: vi.mocked((await import('../../utils/build.js')).buildAppBundle),
       runInRuntime: vi.mocked((await import('./runtime.js')).runInRuntime),
     })
 
     it('should run the app on the selected runtime', async () => {
-      const { buildAppBundle, runInRuntime } = await getMocks()
+      const { runInRuntime } = await getMocks()
       mockModules.existsSync.mockReturnValue(true)
       mockModules.realpathSync.mockReturnValue('test-app.js')
       mockModules.resolve.mockImplementation((cwd: string, path: string) => `${cwd}/${path}`)
-      buildAppBundle.mockResolvedValue('bundled code')
       runInRuntime.mockResolvedValue({
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -1148,8 +1145,7 @@ describe('requestCommand', () => {
         'test-app.js',
       ])
 
-      expect(buildAppBundle).toHaveBeenCalledWith('test-app.js', [])
-      expect(runInRuntime).toHaveBeenCalledWith('bun', 'bundled code', {
+      expect(runInRuntime).toHaveBeenCalledWith('bun', 'test-app.js', [], {
         path: '/api',
         method: 'GET',
         headers: { 'X-Key': 'abc' },

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -2,7 +2,6 @@ import type { Command } from 'commander'
 import type { Hono } from 'hono'
 import { readFileSync } from 'node:fs'
 import type { CommandAgentContext } from '../../utils/agent-context.js'
-import { buildAppBundle } from '../../utils/build.js'
 import { getFilenameFromPath, saveFile } from '../../utils/file.js'
 import { getBuildIterator, readStdin, resolveEntry } from '../../utils/load-app.js'
 import { CliError, handleErrors, printResult } from '../../utils/output.js'
@@ -114,8 +113,7 @@ export function requestCommand(program: Command) {
         options.data = resolveData(options.data)
 
         if (runtime !== 'node') {
-          const bundle = await buildAppBundle(resolveEntry(file), external)
-          const runnerResponse = await runInRuntime(runtime, bundle, {
+          const runnerResponse = await runInRuntime(runtime, resolveEntry(file), external, {
             path,
             method: options.method || 'GET',
             headers: parseHeaders(options.header),

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -2,26 +2,31 @@ import type { Command } from 'commander'
 import type { Hono } from 'hono'
 import { readFileSync } from 'node:fs'
 import type { CommandAgentContext } from '../../utils/agent-context.js'
+import { buildAppBundle } from '../../utils/build.js'
 import { getFilenameFromPath, saveFile } from '../../utils/file.js'
-import { getBuildIterator, readStdin } from '../../utils/load-app.js'
+import { getBuildIterator, readStdin, resolveEntry } from '../../utils/load-app.js'
 import { CliError, handleErrors, printResult } from '../../utils/output.js'
+import type { Runtime } from './runtime.js'
+import { RUNTIMES, runInRuntime } from './runtime.js'
 import { withTracer } from './trace.js'
 
 export const agentContext: CommandAgentContext = {
   output:
     '{ "status": 200, "headers": { "content-type": "application/json" }, "body": { "message": "Hello" } }',
-  errors: ['ENTRY_NOT_FOUND'],
+  errors: ['ENTRY_NOT_FOUND', 'RUNTIME_NOT_FOUND', 'RUNTIME_FAILED'],
   examples: [
     'hono request -P /api/users',
     `hono request -P /api/users -X POST -d '{"name":"Alice"}'`,
     'cat payload.json | hono request -P /api/users -X POST -d @-',
     'hono request -P /api/users/123 --trace',
+    'hono request -P / --runtime bun',
     `echo 'app.get("/hello", (c) => c.json({ ok: true }))' | hono request - -P /hello`,
   ],
   notes: [
     'No server needed. The request goes directly to app.request().',
     'Pass - as the file to read the app code from stdin. `app` is predefined and exported for you — write only routes. Code with its own `export default` is used as-is.',
     '-d @file reads the body from a file, -d @- reads it from stdin.',
+    '--runtime runs the app on bun or deno instead of Node.js. The runtime must be installed.',
     '--trace adds matchedRoutes to the output: which middleware and handler matched, and which one responded. Use it to debug an unexpected response.',
     'A JSON response body is embedded as an object. A binary body becomes null with "binary": true — save it with -o.',
   ],
@@ -35,6 +40,7 @@ interface RequestOptions {
   watch: boolean
   plain: boolean
   trace: boolean
+  runtime: string
   output?: string
   remoteName: boolean
   include: boolean
@@ -63,6 +69,7 @@ export function requestCommand(program: Command) {
     .option('-O, --remote-name', 'Write response body to file named as remote file', false)
     .option('--plain', 'human-readable output instead of JSON', false)
     .option('--trace', 'include matched routes in the output', false)
+    .option('--runtime <runtime>', 'runtime to execute the app (node | bun | deno)', 'node')
     .option('-i, --include', 'Include protocol and headers in the output (with --plain)', false)
     .option('-I, --head', 'Show only protocol and headers in the output (with --plain)', false)
     .option(
@@ -79,6 +86,21 @@ export function requestCommand(program: Command) {
         const path = options.path || '/'
         const watch = options.watch
         const external = options.external || []
+        if (!RUNTIMES.includes(options.runtime as Runtime)) {
+          throw new CliError('INVALID_OPTION', `Unknown runtime: ${options.runtime}`, {
+            suggestions: ['Use one of: node, bun, deno'],
+          })
+        }
+        const runtime = options.runtime as Runtime
+        if (runtime !== 'node' && (options.watch || options.trace)) {
+          throw new CliError(
+            'INVALID_OPTION',
+            `Cannot use --watch or --trace with --runtime ${runtime}`,
+            {
+              suggestions: ['Drop --watch and --trace, or use --runtime node'],
+            }
+          )
+        }
         if (options.trace && options.plain) {
           throw new CliError('INVALID_OPTION', 'Cannot use --trace with --plain', {
             suggestions: ['Drop --plain. The trace is part of the JSON output'],
@@ -90,35 +112,70 @@ export function requestCommand(program: Command) {
           })
         }
         options.data = resolveData(options.data)
+
+        if (runtime !== 'node') {
+          const bundle = await buildAppBundle(resolveEntry(file), external)
+          const runnerResponse = await runInRuntime(runtime, bundle, {
+            path,
+            method: options.method || 'GET',
+            headers: parseHeaders(options.header),
+            ...(options.data === undefined ? {} : { body: options.data }),
+          })
+          const bytes = Buffer.from(runnerResponse.bodyBase64, 'base64')
+          const result = {
+            status: runnerResponse.status,
+            headers: runnerResponse.headers,
+            body: new TextDecoder().decode(bytes),
+            response: new Response(bytes, {
+              status: runnerResponse.status,
+              headers: runnerResponse.headers,
+            }),
+          }
+          await printResponse(result, path, options, doSaveFile, { runtime })
+          return
+        }
+
         const buildIterator = getBuildIterator(file, watch, external)
         for await (const app of buildIterator) {
           const traced = options.trace ? withTracer(app) : undefined
           const result = await executeRequest(traced?.app ?? app, path, options)
-          const contentType = result.headers['content-type']
-          const buffer = await result.response.clone().arrayBuffer()
-          const isBinaryData = isBinaryResponse(buffer)
-
-          let savedTo: string | undefined
-          if (doSaveFile) {
-            savedTo = await handleSaveOutput(buffer, path, options, contentType)
-          }
-
-          if (options.plain) {
-            printPlain(result, contentType, isBinaryData, savedTo, options)
-            continue
-          }
-
-          printResult({
-            status: result.status,
-            headers: result.headers,
-            body: isBinaryData ? null : parseBody(result.body, contentType),
-            ...(isBinaryData ? { binary: true } : {}),
-            ...(savedTo ? { savedTo } : {}),
+          await printResponse(result, path, options, doSaveFile, {
             ...(traced ? { matchedRoutes: traced.getTrace() } : {}),
           })
         }
       })
     )
+}
+
+const printResponse = async (
+  result: { status: number; body: string; headers: Record<string, string>; response: Response },
+  path: string,
+  options: RequestOptions,
+  doSaveFile: string | boolean | undefined,
+  extra: Record<string, unknown>
+): Promise<void> => {
+  const contentType = result.headers['content-type']
+  const buffer = await result.response.clone().arrayBuffer()
+  const isBinaryData = isBinaryResponse(buffer)
+
+  let savedTo: string | undefined
+  if (doSaveFile) {
+    savedTo = await handleSaveOutput(buffer, path, options, contentType)
+  }
+
+  if (options.plain) {
+    printPlain(result, contentType, isBinaryData, savedTo, options)
+    return
+  }
+
+  printResult({
+    status: result.status,
+    headers: result.headers,
+    body: isBinaryData ? null : parseBody(result.body, contentType),
+    ...(isBinaryData ? { binary: true } : {}),
+    ...(savedTo ? { savedTo } : {}),
+    ...extra,
+  })
 }
 
 const printPlain = (
@@ -171,6 +228,17 @@ const handleSaveOutput = async (
   }
 }
 
+const parseHeaders = (header: string[] | undefined): Record<string, string> => {
+  const headers: Record<string, string> = {}
+  for (const entry of header ?? []) {
+    const [key, value] = entry.split(':', 2)
+    if (key && value) {
+      headers[key.trim()] = value.trim()
+    }
+  }
+  return headers
+}
+
 const resolveData = (data: string | undefined): string | undefined => {
   if (data === undefined || !data.startsWith('@')) {
     return data
@@ -199,14 +267,7 @@ export async function executeRequest(
 
   // Add headers if provided
   if (options.header && options.header.length > 0) {
-    const headers = new Headers()
-    for (const header of options.header) {
-      const [key, value] = header.split(':', 2)
-      if (key && value) {
-        headers.set(key.trim(), value.trim())
-      }
-    }
-    requestInit.headers = headers
+    requestInit.headers = parseHeaders(options.header)
   }
 
   // Execute request

--- a/src/commands/request/runtime.test.ts
+++ b/src/commands/request/runtime.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { execFile } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { buildRunnerScript } from './runtime'
+
+const execNode = (script: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    execFile(process.execPath, [script], (error, _stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr))
+        return
+      }
+      resolve()
+    })
+  })
+
+describe('buildRunnerScript', () => {
+  let dir: string
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const run = async (appCode: string, request: Parameters<typeof buildRunnerScript>[2]) => {
+    dir = mkdtempSync(join(tmpdir(), 'hono-cli-runner-test'))
+    const bundlePath = join(dir, 'app.mjs')
+    const runnerPath = join(dir, 'runner.mjs')
+    const resultPath = join(dir, 'result.json')
+    writeFileSync(bundlePath, appCode)
+    writeFileSync(
+      runnerPath,
+      buildRunnerScript(pathToFileURL(bundlePath).href, resultPath, request)
+    )
+    await execNode(runnerPath)
+    return JSON.parse(readFileSync(resultPath, 'utf-8'))
+  }
+
+  it('should send the request and write the response', async () => {
+    const result = await run(
+      `export default {
+        request: async (req) => {
+          const url = new URL(req.url)
+          return new Response(JSON.stringify({ path: url.pathname, body: await req.text() }), {
+            status: 201,
+            headers: { 'content-type': 'application/json', 'x-extra': 'yes' },
+          })
+        },
+      }`,
+      { path: '/echo', method: 'POST', headers: { 'x-in': 'abc' }, body: 'hello' }
+    )
+
+    expect(result.status).toBe(201)
+    expect(result.headers['content-type']).toBe('application/json')
+    expect(result.headers['x-extra']).toBe('yes')
+    const body = JSON.parse(Buffer.from(result.bodyBase64, 'base64').toString('utf-8'))
+    expect(body).toEqual({ path: '/echo', body: 'hello' })
+  })
+
+  it('should fall back to fetch when the app has no request method', async () => {
+    const result = await run(
+      `export default {
+        fetch: (req) => new Response('from fetch', { headers: { 'x-h': req.headers.get('x-in') } }),
+      }`,
+      { path: '/', method: 'GET', headers: { 'x-in': 'v' } }
+    )
+
+    expect(result.status).toBe(200)
+    expect(result.headers['x-h']).toBe('v')
+    expect(Buffer.from(result.bodyBase64, 'base64').toString('utf-8')).toBe('from fetch')
+  })
+
+  it('should carry a binary body as base64', async () => {
+    const result = await run(
+      `export default {
+        fetch: () => new Response(new Uint8Array([0, 1, 254, 255]), {
+          headers: { 'content-type': 'application/octet-stream' },
+        }),
+      }`,
+      { path: '/', method: 'GET', headers: {} }
+    )
+
+    expect([...Buffer.from(result.bodyBase64, 'base64')]).toEqual([0, 1, 254, 255])
+  })
+})

--- a/src/commands/request/runtime.test.ts
+++ b/src/commands/request/runtime.test.ts
@@ -1,46 +1,32 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { execFile } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { pathToFileURL } from 'node:url'
-import { buildRunnerScript } from './runtime'
+import { CliError } from '../../utils/output'
+import { buildRunnerBody, parseRunnerOutput } from './runtime'
 
-const execNode = (script: string): Promise<void> =>
+const MARKER = '__TEST_MARKER__'
+
+const execNode = (code: string): Promise<string> =>
   new Promise((resolve, reject) => {
-    execFile(process.execPath, [script], (error, _stdout, stderr) => {
+    const child = execFile(process.execPath, ['--input-type=module'], (error, stdout, stderr) => {
       if (error) {
         reject(new Error(stderr))
         return
       }
-      resolve()
+      resolve(stdout)
     })
+    child.stdin?.end(code)
   })
 
-describe('buildRunnerScript', () => {
-  let dir: string
-
-  afterEach(() => {
-    rmSync(dir, { recursive: true, force: true })
-  })
-
-  const run = async (appCode: string, request: Parameters<typeof buildRunnerScript>[2]) => {
-    dir = mkdtempSync(join(tmpdir(), 'hono-cli-runner-test'))
-    const bundlePath = join(dir, 'app.mjs')
-    const runnerPath = join(dir, 'runner.mjs')
-    const resultPath = join(dir, 'result.json')
-    writeFileSync(bundlePath, appCode)
-    writeFileSync(
-      runnerPath,
-      buildRunnerScript(pathToFileURL(bundlePath).href, resultPath, request)
-    )
-    await execNode(runnerPath)
-    return JSON.parse(readFileSync(resultPath, 'utf-8'))
+describe('buildRunnerBody', () => {
+  const run = async (appExpr: string, request: Parameters<typeof buildRunnerBody>[0]) => {
+    const code = `const app = ${appExpr}\n${buildRunnerBody(request, MARKER)}`
+    const stdout = await execNode(code)
+    return parseRunnerOutput(stdout, MARKER, 'node')
   }
 
-  it('should send the request and write the response', async () => {
+  it('should send the request and print the response as a marker line', async () => {
     const result = await run(
-      `export default {
+      `{
         request: async (req) => {
           const url = new URL(req.url)
           return new Response(JSON.stringify({ path: url.pathname, body: await req.text() }), {
@@ -53,7 +39,6 @@ describe('buildRunnerScript', () => {
     )
 
     expect(result.status).toBe(201)
-    expect(result.headers['content-type']).toBe('application/json')
     expect(result.headers['x-extra']).toBe('yes')
     const body = JSON.parse(Buffer.from(result.bodyBase64, 'base64').toString('utf-8'))
     expect(body).toEqual({ path: '/echo', body: 'hello' })
@@ -61,9 +46,7 @@ describe('buildRunnerScript', () => {
 
   it('should fall back to fetch when the app has no request method', async () => {
     const result = await run(
-      `export default {
-        fetch: (req) => new Response('from fetch', { headers: { 'x-h': req.headers.get('x-in') } }),
-      }`,
+      `{ fetch: (req) => new Response('from fetch', { headers: { 'x-h': req.headers.get('x-in') } }) }`,
       { path: '/', method: 'GET', headers: { 'x-in': 'v' } }
     )
 
@@ -73,15 +56,34 @@ describe('buildRunnerScript', () => {
   })
 
   it('should carry a binary body as base64', async () => {
-    const result = await run(
-      `export default {
-        fetch: () => new Response(new Uint8Array([0, 1, 254, 255]), {
-          headers: { 'content-type': 'application/octet-stream' },
-        }),
-      }`,
-      { path: '/', method: 'GET', headers: {} }
-    )
+    const result = await run(`{ fetch: () => new Response(new Uint8Array([0, 1, 254, 255])) }`, {
+      path: '/',
+      method: 'GET',
+      headers: {},
+    })
 
     expect([...Buffer.from(result.bodyBase64, 'base64')]).toEqual([0, 1, 254, 255])
+  })
+})
+
+describe('parseRunnerOutput', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should pick the marker line and forward other lines to stderr', () => {
+    const write = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const result = parseRunnerOutput(
+      `app log noise\n${MARKER}{"status":200,"headers":{},"bodyBase64":""}\n`,
+      MARKER,
+      'bun'
+    )
+    expect(result.status).toBe(200)
+    expect(write).toHaveBeenCalledWith('app log noise\n')
+  })
+
+  it('should throw RUNTIME_FAILED when the marker line is missing', () => {
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    expect(() => parseRunnerOutput('only logs\n', MARKER, 'bun')).toThrowError(CliError)
   })
 })

--- a/src/commands/request/runtime.test.ts
+++ b/src/commands/request/runtime.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { execFile } from 'node:child_process'
+import { execFile, execFileSync } from 'node:child_process'
 import { CliError } from '../../utils/output'
-import { buildRunnerBody, parseRunnerOutput } from './runtime'
+import { buildRunnerBody, parseRunnerOutput, runInRuntime } from './runtime'
 
 const MARKER = '__TEST_MARKER__'
 
@@ -65,6 +65,38 @@ describe('buildRunnerBody', () => {
     expect([...Buffer.from(result.bodyBase64, 'base64')]).toEqual([0, 1, 254, 255])
   })
 })
+
+// Run only where the runtime is installed. CI does not have them.
+const hasRuntime = (bin: string): boolean => {
+  try {
+    execFileSync('which', [bin], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+for (const runtime of ['bun', 'deno'] as const) {
+  describe.runIf(hasRuntime(runtime))(`runInRuntime on ${runtime}`, () => {
+    it('should run the app and return the response', async () => {
+      const result = await runInRuntime(
+        runtime,
+        {
+          code: [
+            'const app = { fetch: () => new Response(JSON.stringify({ ua: navigator.userAgent })) }',
+            'export default app',
+          ].join('\n'),
+        },
+        [],
+        { path: '/', method: 'GET', headers: {} }
+      )
+
+      expect(result.status).toBe(200)
+      const body = JSON.parse(Buffer.from(result.bodyBase64, 'base64').toString('utf-8'))
+      expect(body.ua).toContain(runtime === 'bun' ? 'Bun/' : 'Deno/')
+    })
+  })
+}
 
 describe('parseRunnerOutput', () => {
   afterEach(() => {

--- a/src/commands/request/runtime.test.ts
+++ b/src/commands/request/runtime.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { execFile, execFileSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { CliError } from '../../utils/output'
-import { buildRunnerBody, parseRunnerOutput, runInRuntime } from './runtime'
+import { buildRunnerBody, parseRunnerOutput } from './runtime'
 
 const MARKER = '__TEST_MARKER__'
 
@@ -65,38 +65,6 @@ describe('buildRunnerBody', () => {
     expect([...Buffer.from(result.bodyBase64, 'base64')]).toEqual([0, 1, 254, 255])
   })
 })
-
-// Run only where the runtime is installed. CI does not have them.
-const hasRuntime = (bin: string): boolean => {
-  try {
-    execFileSync('which', [bin], { stdio: 'ignore' })
-    return true
-  } catch {
-    return false
-  }
-}
-
-for (const runtime of ['bun', 'deno'] as const) {
-  describe.runIf(hasRuntime(runtime))(`runInRuntime on ${runtime}`, () => {
-    it('should run the app and return the response', async () => {
-      const result = await runInRuntime(
-        runtime,
-        {
-          code: [
-            'const app = { fetch: () => new Response(JSON.stringify({ ua: navigator.userAgent })) }',
-            'export default app',
-          ].join('\n'),
-        },
-        [],
-        { path: '/', method: 'GET', headers: {} }
-      )
-
-      expect(result.status).toBe(200)
-      const body = JSON.parse(Buffer.from(result.bodyBase64, 'base64').toString('utf-8'))
-      expect(body.ua).toContain(runtime === 'bun' ? 'Bun/' : 'Deno/')
-    })
-  })
-}
 
 describe('parseRunnerOutput', () => {
   afterEach(() => {

--- a/src/commands/request/runtime.ts
+++ b/src/commands/request/runtime.ts
@@ -1,0 +1,129 @@
+import { execFile } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { CliError } from '../../utils/output.js'
+
+export const RUNTIMES = ['node', 'bun', 'deno'] as const
+export type Runtime = (typeof RUNTIMES)[number]
+
+export interface RunnerRequest {
+  path: string
+  method: string
+  headers: Record<string, string>
+  body?: string
+}
+
+export interface RunnerResponse {
+  status: number
+  headers: Record<string, string>
+  bodyBase64: string
+}
+
+/**
+ * The script imports the bundled app, sends the request, and writes the
+ * response to a file. stdout stays free for the app's own logs.
+ */
+export const buildRunnerScript = (
+  bundleUrl: string,
+  resultPath: string,
+  request: RunnerRequest
+): string => `import { writeFileSync } from 'node:fs'
+import app from ${JSON.stringify(bundleUrl)}
+
+const req = ${JSON.stringify(request)}
+const target = new Request(new URL(req.path, 'http://localhost'), {
+  method: req.method,
+  headers: req.headers,
+  ...(req.body === undefined ? {} : { body: req.body }),
+})
+const handler = typeof app.request === 'function' ? app.request.bind(app) : app.fetch.bind(app)
+const response = await handler(target)
+const bytes = new Uint8Array(await response.arrayBuffer())
+let binary = ''
+for (let i = 0; i < bytes.length; i += 0x8000) {
+  binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000))
+}
+const headers = {}
+response.headers.forEach((value, key) => {
+  headers[key] = value
+})
+writeFileSync(
+  ${JSON.stringify(resultPath)},
+  JSON.stringify({ status: response.status, headers, bodyBase64: btoa(binary) })
+)
+`
+
+interface RunnerCommand {
+  bin: string
+  args: (dir: string) => string[]
+  install: string
+}
+
+const RUNNER_COMMANDS: Record<Exclude<Runtime, 'node'>, RunnerCommand> = {
+  bun: { bin: 'bun', args: () => [], install: 'Install Bun: https://bun.sh' },
+  deno: {
+    bin: 'deno',
+    args: (dir) => ['run', '--quiet', `--allow-write=${dir}`],
+    install: 'Install Deno: https://deno.com',
+  },
+}
+
+export const runInRuntime = async (
+  runtime: Exclude<Runtime, 'node'>,
+  bundleCode: string,
+  request: RunnerRequest
+): Promise<RunnerResponse> => {
+  // Under node_modules so that packages marked as external still resolve
+  const base = join(process.cwd(), 'node_modules', '.hono-cli')
+  mkdirSync(base, { recursive: true })
+  const dir = mkdtempSync(join(base, 'run-'))
+
+  try {
+    const bundlePath = join(dir, 'app.mjs')
+    const runnerPath = join(dir, 'runner.mjs')
+    const resultPath = join(dir, 'result.json')
+    writeFileSync(bundlePath, bundleCode)
+    writeFileSync(
+      runnerPath,
+      buildRunnerScript(pathToFileURL(bundlePath).href, resultPath, request)
+    )
+
+    const command = RUNNER_COMMANDS[runtime]
+    await execRunner(runtime, command.bin, [...command.args(dir), runnerPath], command.install)
+
+    return JSON.parse(readFileSync(resultPath, 'utf-8'))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+const execRunner = (runtime: string, bin: string, args: string[], install: string): Promise<void> =>
+  new Promise((resolvePromise, reject) => {
+    execFile(bin, args, { maxBuffer: 64 * 1024 * 1024 }, (error, stdout, stderr) => {
+      // The app's own logs go to stderr
+      if (stdout) {
+        process.stderr.write(stdout)
+      }
+      if (stderr) {
+        process.stderr.write(stderr)
+      }
+      if (!error) {
+        resolvePromise()
+        return
+      }
+      if ('code' in error && error.code === 'ENOENT') {
+        reject(
+          new CliError('RUNTIME_NOT_FOUND', `${bin} is not installed`, {
+            suggestions: [install, 'Or drop --runtime to run on Node.js'],
+          })
+        )
+        return
+      }
+      reject(
+        new CliError('RUNTIME_FAILED', `The app failed on ${runtime}`, {
+          suggestions: ['Check the error output above'],
+        })
+      )
+    })
+  })

--- a/src/commands/request/runtime.ts
+++ b/src/commands/request/runtime.ts
@@ -1,7 +1,7 @@
+import * as esbuild from 'esbuild'
 import { execFile } from 'node:child_process'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { randomUUID } from 'node:crypto'
+import type { AppEntry } from '../../utils/build.js'
 import { CliError } from '../../utils/output.js'
 
 export const RUNTIMES = ['node', 'bun', 'deno'] as const
@@ -21,16 +21,11 @@ export interface RunnerResponse {
 }
 
 /**
- * The script imports the bundled app, sends the request, and writes the
- * response to a file. stdout stays free for the app's own logs.
+ * The runner runs after the app import. It sends the request and prints
+ * the response as one marker line, so the app's own logs cannot break
+ * the protocol.
  */
-export const buildRunnerScript = (
-  bundleUrl: string,
-  resultPath: string,
-  request: RunnerRequest
-): string => `import { writeFileSync } from 'node:fs'
-import app from ${JSON.stringify(bundleUrl)}
-
+export const buildRunnerBody = (request: RunnerRequest, marker: string): string => `
 const req = ${JSON.stringify(request)}
 const target = new Request(new URL(req.path, 'http://localhost'), {
   method: req.method,
@@ -48,82 +43,127 @@ const headers = {}
 response.headers.forEach((value, key) => {
   headers[key] = value
 })
-writeFileSync(
-  ${JSON.stringify(resultPath)},
-  JSON.stringify({ status: response.status, headers, bodyBase64: btoa(binary) })
+console.log(
+  ${JSON.stringify(marker)} + JSON.stringify({ status: response.status, headers, bodyBase64: btoa(binary) })
 )
 `
 
+const virtualAppPlugin = (code: string): esbuild.Plugin => ({
+  name: 'virtual-app',
+  setup(build) {
+    build.onResolve({ filter: /^virtual:app$/ }, () => ({
+      path: 'virtual:app',
+      namespace: 'virtual',
+    }))
+    build.onLoad({ filter: /^virtual:app$/, namespace: 'virtual' }, () => ({
+      contents: code,
+      loader: 'tsx',
+      resolveDir: process.cwd(),
+    }))
+  },
+})
+
 interface RunnerCommand {
   bin: string
-  args: (dir: string) => string[]
+  args: string[]
   install: string
 }
 
 const RUNNER_COMMANDS: Record<Exclude<Runtime, 'node'>, RunnerCommand> = {
-  bun: { bin: 'bun', args: () => [], install: 'Install Bun: https://bun.sh' },
-  deno: {
-    bin: 'deno',
-    args: (dir) => ['run', '--quiet', `--allow-write=${dir}`],
-    install: 'Install Deno: https://deno.com',
-  },
+  bun: { bin: 'bun', args: ['run', '-'], install: 'Install Bun: https://bun.sh' },
+  deno: { bin: 'deno', args: ['run', '--quiet', '-'], install: 'Install Deno: https://deno.com' },
 }
 
+/**
+ * Bundle the app together with the runner and pipe it to the runtime.
+ * No files are written. Packages marked as external resolve from the
+ * working directory.
+ */
 export const runInRuntime = async (
   runtime: Exclude<Runtime, 'node'>,
-  bundleCode: string,
+  entry: AppEntry,
+  external: string[],
   request: RunnerRequest
 ): Promise<RunnerResponse> => {
-  // Under node_modules so that packages marked as external still resolve
-  const base = join(process.cwd(), 'node_modules', '.hono-cli')
-  mkdirSync(base, { recursive: true })
-  const dir = mkdtempSync(join(base, 'run-'))
+  const marker = `__HONO_CLI_RESULT_${randomUUID()}__`
+  const body = buildRunnerBody(request, marker)
+  const [importSource, plugins] =
+    typeof entry === 'string' ? [entry, []] : ['virtual:app', [virtualAppPlugin(entry.code)]]
 
-  try {
-    const bundlePath = join(dir, 'app.mjs')
-    const runnerPath = join(dir, 'runner.mjs')
-    const resultPath = join(dir, 'result.json')
-    writeFileSync(bundlePath, bundleCode)
-    writeFileSync(
-      runnerPath,
-      buildRunnerScript(pathToFileURL(bundlePath).href, resultPath, request)
-    )
+  const built = await esbuild.build({
+    stdin: {
+      contents: `import app from ${JSON.stringify(importSource)}\n${body}`,
+      resolveDir: process.cwd(),
+      loader: 'tsx',
+      sourcefile: '__runner__.tsx',
+    },
+    bundle: true,
+    write: false,
+    format: 'esm',
+    target: 'esnext',
+    platform: 'node',
+    jsx: 'automatic',
+    jsxImportSource: 'hono/jsx',
+    external: ['@hono/node-server', ...external],
+    plugins,
+  })
 
-    const command = RUNNER_COMMANDS[runtime]
-    await execRunner(runtime, command.bin, [...command.args(dir), runnerPath], command.install)
-
-    return JSON.parse(readFileSync(resultPath, 'utf-8'))
-  } finally {
-    rmSync(dir, { recursive: true, force: true })
-  }
+  const command = RUNNER_COMMANDS[runtime]
+  const stdout = await execRunner(runtime, command, built.outputFiles[0].text)
+  return parseRunnerOutput(stdout, marker, runtime)
 }
 
-const execRunner = (runtime: string, bin: string, args: string[], install: string): Promise<void> =>
+const execRunner = (runtime: string, command: RunnerCommand, code: string): Promise<string> =>
   new Promise((resolvePromise, reject) => {
-    execFile(bin, args, { maxBuffer: 64 * 1024 * 1024 }, (error, stdout, stderr) => {
-      // The app's own logs go to stderr
-      if (stdout) {
-        process.stderr.write(stdout)
-      }
-      if (stderr) {
-        process.stderr.write(stderr)
-      }
-      if (!error) {
-        resolvePromise()
-        return
-      }
-      if ('code' in error && error.code === 'ENOENT') {
+    const child = execFile(
+      command.bin,
+      command.args,
+      { maxBuffer: 64 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        // The app's own logs go to stderr
+        if (stderr) {
+          process.stderr.write(stderr)
+        }
+        if (!error) {
+          resolvePromise(stdout)
+          return
+        }
+        if (stdout) {
+          process.stderr.write(stdout)
+        }
+        if ('code' in error && error.code === 'ENOENT') {
+          reject(
+            new CliError('RUNTIME_NOT_FOUND', `${command.bin} is not installed`, {
+              suggestions: [command.install, 'Or drop --runtime to run on Node.js'],
+            })
+          )
+          return
+        }
         reject(
-          new CliError('RUNTIME_NOT_FOUND', `${bin} is not installed`, {
-            suggestions: [install, 'Or drop --runtime to run on Node.js'],
+          new CliError('RUNTIME_FAILED', `The app failed on ${runtime}`, {
+            suggestions: ['Check the error output above'],
           })
         )
-        return
       }
-      reject(
-        new CliError('RUNTIME_FAILED', `The app failed on ${runtime}`, {
-          suggestions: ['Check the error output above'],
-        })
-      )
-    })
+    )
+    child.stdin?.end(code)
   })
+
+export const parseRunnerOutput = (
+  stdout: string,
+  marker: string,
+  runtime: string
+): RunnerResponse => {
+  const lines = stdout.split('\n')
+  const resultLine = lines.find((line) => line.includes(marker))
+  const logs = lines.filter((line) => line !== resultLine && line.length > 0)
+  if (logs.length > 0) {
+    process.stderr.write(logs.join('\n') + '\n')
+  }
+  if (resultLine === undefined) {
+    throw new CliError('RUNTIME_FAILED', `No result from ${runtime}`, {
+      suggestions: ['Check the error output above'],
+    })
+  }
+  return JSON.parse(resultLine.slice(resultLine.indexOf(marker) + marker.length))
+}

--- a/src/utils/build.ts
+++ b/src/utils/build.ts
@@ -25,25 +25,6 @@ const entryConfigOf = (entry: AppEntry) =>
       }
 
 /**
- * Bundle the app into a single ESM string, without importing it.
- * Used to run the app in another runtime.
- */
-export async function buildAppBundle(entry: AppEntry, external: string[] = []): Promise<string> {
-  const result = await esbuild.build({
-    ...entryConfigOf(entry),
-    bundle: true,
-    write: false,
-    format: 'esm',
-    target: 'esnext',
-    jsx: 'automatic',
-    jsxImportSource: 'hono/jsx',
-    platform: 'node',
-    external,
-  })
-  return result.outputFiles[0].text
-}
-
-/**
  * Build and import a TypeScript/JSX/JS app from a file or from code
  */
 export async function* buildAndImportApp(

--- a/src/utils/build.ts
+++ b/src/utils/build.ts
@@ -12,6 +12,37 @@ export interface BuildOptions {
 /** App source: a file path, or code read from stdin */
 export type AppEntry = string | { code: string }
 
+const entryConfigOf = (entry: AppEntry) =>
+  typeof entry === 'string'
+    ? { entryPoints: [entry] }
+    : {
+        stdin: {
+          contents: entry.code,
+          resolveDir: process.cwd(),
+          loader: 'tsx' as const,
+          sourcefile: '__stdin__.tsx',
+        },
+      }
+
+/**
+ * Bundle the app into a single ESM string, without importing it.
+ * Used to run the app in another runtime.
+ */
+export async function buildAppBundle(entry: AppEntry, external: string[] = []): Promise<string> {
+  const result = await esbuild.build({
+    ...entryConfigOf(entry),
+    bundle: true,
+    write: false,
+    format: 'esm',
+    target: 'esnext',
+    jsx: 'automatic',
+    jsxImportSource: 'hono/jsx',
+    platform: 'node',
+    external,
+  })
+  return result.outputFiles[0].text
+}
+
 /**
  * Build and import a TypeScript/JSX/JS app from a file or from code
  */
@@ -29,17 +60,7 @@ export async function* buildAndImportApp(
   }
   preparePromise()
 
-  const entryConfig =
-    typeof entry === 'string'
-      ? { entryPoints: [entry] }
-      : {
-          stdin: {
-            contents: entry.code,
-            resolveDir: process.cwd(),
-            loader: 'tsx' as const,
-            sourcefile: '__stdin__.tsx',
-          },
-        }
+  const entryConfig = entryConfigOf(entry)
 
   const context = await esbuild.context({
     ...entryConfig,

--- a/src/utils/load-app.ts
+++ b/src/utils/load-app.ts
@@ -1,6 +1,7 @@
 import type { Hono } from 'hono'
 import { existsSync, realpathSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import type { AppEntry } from './build.js'
 import { buildAndImportApp } from './build.js'
 import { CliError } from './output.js'
 
@@ -20,10 +21,25 @@ export function getBuildIterator(
         suggestions: ['Pass a file path instead of - when using --watch'],
       })
     }
-    return buildAndImportApp(
-      { code: wrapCode(readStdin()) },
-      { external: ['@hono/node-server', ...external] }
-    )
+    return buildAndImportApp(resolveEntry(appPath), {
+      external: ['@hono/node-server', ...external],
+    })
+  }
+
+  return buildAndImportApp(resolveEntry(appPath), {
+    external: ['@hono/node-server', ...external],
+    watch,
+    sourcemap: true,
+  })
+}
+
+/**
+ * Resolve the app source: `-` reads code from stdin, a path is used
+ * as-is, and without a path the default candidates are tried.
+ */
+export function resolveEntry(appPath: string | undefined): AppEntry {
+  if (appPath === '-') {
+    return { code: wrapCode(readStdin()) }
   }
 
   let entry: string
@@ -50,12 +66,7 @@ export function getBuildIterator(
     })
   }
 
-  const appFilePath = realpathSync(resolvedAppPath)
-  return buildAndImportApp(appFilePath, {
-    external: ['@hono/node-server', ...external],
-    watch,
-    sourcemap: true,
-  })
+  return realpathSync(resolvedAppPath)
 }
 
 export const readStdin = (): string => {


### PR DESCRIPTION
Add `--runtime <node | bun | deno>` to `hono request` (part of #77). The default `node` runs in-process as before. For `bun` and `deno`, the CLI bundles the app together with a small runner and pipes it to `bun run -` / `deno run --quiet -`. No files are written.

- Packages marked with `-e` stay external and resolve from the working directory
- The runner prints the response as one marker line, so the app's own logs cannot break the protocol. The logs go to stderr
- Deno needs no permission flags
- A missing runtime is a `RUNTIME_NOT_FOUND` error with install suggestions. A crash on the runtime is `RUNTIME_FAILED`
- `--watch` / `--trace` with a non-node runtime is `INVALID_OPTION`
- Verified on real Bun 1.3.14 and Deno 2.3.7: `navigator.userAgent` returns `Bun/...` / `Deno/...`

Cloudflare Workers (workerd) comes later — it needs miniflare and binding resolution.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code