### PR TITLE
docs: order the sections like the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Build:
 - `optimize [entry]` - Build an optimized Hono app
 - `ssg [file]` - Generate static files from your Hono app
 
+---
+
+### `agent-context`
+
+Show how to use Hono CLI, as Markdown for coding agents. The content is generated from the command definitions, so it always matches the installed version.
+
+```bash
+hono agent-context
+```
+
 ### `routes`
 
 Show all routes of your Hono app, like [`showRoutes()`](https://hono.dev/docs/helpers/dev#showroutes).
@@ -318,14 +328,6 @@ hono ssg --exclude '/api/*'
     "files": ["static/index.html", "static/about.html"]
   }
 }
-```
-
-### `agent-context`
-
-Show how to use Hono CLI, as Markdown for coding agents. The content is generated from the command definitions, so it always matches the installed version.
-
-```bash
-hono agent-context
 ```
 
 ## Tips


### PR DESCRIPTION
Follow-up to #100. Add a separator between the command list and the detail sections, and order the sections like the list: agent-context, routes, request, optimize, ssg.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code