### PR TITLE
feat(request): add workerd to --runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ hono request [file] [options]
 - `-O, --remote-name` - Write response body to file named as remote file
 - `--plain` - human-readable output instead of JSON
 - `--trace` - include matched routes in the output
-- `--runtime <runtime>` - runtime to execute the app: `node` (default), `bun`, or `deno`
+- `--runtime <runtime>` - runtime to execute the app: `node` (default), `bun`, `deno`, or `workerd`
 - `-i, --include` - Include status and headers in the output (with `--plain`)
 - `-I, --head` - Show only status and headers in the output (with `--plain`)
 - `-e, --external <package>` - Mark package as external (can be used multiple times)
@@ -153,7 +153,12 @@ hono request -P /api/users/123 --trace
 # Run the app on another runtime (it must be installed)
 hono request -P / --runtime bun
 hono request -P / --runtime deno
+
+# Run the app on workerd with your wrangler config: bindings (c.env) are the local ones
+hono request -P /api --runtime workerd
 ```
+
+`workerd` starts the app with the wrangler config of the project, so pass no file argument. It needs [wrangler](https://developers.cloudflare.com/workers/wrangler/) installed in the project. wrangler is not a dependency of Hono CLI.
 
 With `--trace`, the output has `matchedRoutes`. `responded` marks the route that returned the response:
 

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -23,6 +23,10 @@ vi.mock('./runtime.js', async (importOriginal) => {
   return { ...original, runInRuntime: vi.fn() }
 })
 
+vi.mock('./workerd.js', () => ({
+  runOnWorkerd: vi.fn(),
+}))
+
 import { requestCommand } from './index.js'
 
 vi.mock('../../utils/file.js', () => ({
@@ -1169,6 +1173,43 @@ describe('requestCommand', () => {
       expect(parsed.ok).toBe(false)
       expect(parsed.error.code).toBe('INVALID_OPTION')
       expect(process.exitCode).toBe(1)
+      process.exitCode = undefined
+    })
+
+    it('should run the app on workerd with the wrangler config', async () => {
+      const runOnWorkerd = vi.mocked((await import('./workerd.js')).runOnWorkerd)
+      const body = JSON.stringify({ who: 'workerd' })
+      runOnWorkerd.mockResolvedValue({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        body,
+        response: new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      })
+
+      await program.parseAsync(['node', 'test', 'request', '-P', '/api', '--runtime', 'workerd'])
+
+      expect(runOnWorkerd).toHaveBeenCalledWith({ path: '/api', method: 'GET', headers: {} })
+      const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+      expect(parsed).toEqual({
+        ok: true,
+        data: {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body: { who: 'workerd' },
+          runtime: 'workerd',
+        },
+      })
+    })
+
+    it('should reject a file argument with workerd', async () => {
+      await program.parseAsync(['node', 'test', 'request', '--runtime', 'workerd', 'src/index.ts'])
+
+      const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+      expect(parsed.ok).toBe(false)
+      expect(parsed.error.code).toBe('INVALID_OPTION')
       process.exitCode = undefined
     })
 

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -7,8 +7,8 @@ import { getBuildIterator, readStdin, resolveEntry } from '../../utils/load-app.
 import { CliError, handleErrors, printResult } from '../../utils/output.js'
 import type { Runtime } from './runtime.js'
 import { RUNTIMES, runInRuntime } from './runtime.js'
-import { runOnWorkerd } from './workerd.js'
 import { withTracer } from './trace.js'
+import { runOnWorkerd } from './workerd.js'
 
 export const agentContext: CommandAgentContext = {
   output:

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -7,25 +7,33 @@ import { getBuildIterator, readStdin, resolveEntry } from '../../utils/load-app.
 import { CliError, handleErrors, printResult } from '../../utils/output.js'
 import type { Runtime } from './runtime.js'
 import { RUNTIMES, runInRuntime } from './runtime.js'
+import { runOnWorkerd } from './workerd.js'
 import { withTracer } from './trace.js'
 
 export const agentContext: CommandAgentContext = {
   output:
     '{ "status": 200, "headers": { "content-type": "application/json" }, "body": { "message": "Hello" } }',
-  errors: ['ENTRY_NOT_FOUND', 'RUNTIME_NOT_FOUND', 'RUNTIME_FAILED'],
+  errors: [
+    'ENTRY_NOT_FOUND',
+    'RUNTIME_NOT_FOUND',
+    'RUNTIME_FAILED',
+    'WRANGLER_NOT_FOUND',
+    'WRANGLER_CONFIG_NOT_FOUND',
+  ],
   examples: [
     'hono request -P /api/users',
     `hono request -P /api/users -X POST -d '{"name":"Alice"}'`,
     'cat payload.json | hono request -P /api/users -X POST -d @-',
     'hono request -P /api/users/123 --trace',
     'hono request -P / --runtime bun',
+    'hono request -P /api --runtime workerd',
     `echo 'app.get("/hello", (c) => c.json({ ok: true }))' | hono request - -P /hello`,
   ],
   notes: [
     'No server needed. The request goes directly to app.request().',
     'Pass - as the file to read the app code from stdin. `app` is predefined and exported for you — write only routes. Code with its own `export default` is used as-is.',
     '-d @file reads the body from a file, -d @- reads it from stdin.',
-    '--runtime runs the app on bun or deno instead of Node.js. The runtime must be installed.',
+    '--runtime runs the app on bun, deno, or workerd instead of Node.js. bun and deno must be installed. workerd starts the app with the wrangler config of the project, so the local bindings (c.env) are real — it needs wrangler installed and no file argument.',
     '--trace adds matchedRoutes to the output: which middleware and handler matched, and which one responded. Use it to debug an unexpected response.',
     'A JSON response body is embedded as an object. A binary body becomes null with "binary": true — save it with -o.',
   ],
@@ -68,7 +76,11 @@ export function requestCommand(program: Command) {
     .option('-O, --remote-name', 'Write response body to file named as remote file', false)
     .option('--plain', 'human-readable output instead of JSON', false)
     .option('--trace', 'include matched routes in the output', false)
-    .option('--runtime <runtime>', 'runtime to execute the app (node | bun | deno)', 'node')
+    .option(
+      '--runtime <runtime>',
+      'runtime to execute the app (node | bun | deno | workerd)',
+      'node'
+    )
     .option('-i, --include', 'Include protocol and headers in the output (with --plain)', false)
     .option('-I, --head', 'Show only protocol and headers in the output (with --plain)', false)
     .option(
@@ -87,7 +99,7 @@ export function requestCommand(program: Command) {
         const external = options.external || []
         if (!RUNTIMES.includes(options.runtime as Runtime)) {
           throw new CliError('INVALID_OPTION', `Unknown runtime: ${options.runtime}`, {
-            suggestions: ['Use one of: node, bun, deno'],
+            suggestions: ['Use one of: node, bun, deno, workerd'],
           })
         }
         const runtime = options.runtime as Runtime
@@ -111,6 +123,22 @@ export function requestCommand(program: Command) {
           })
         }
         options.data = resolveData(options.data)
+
+        if (runtime === 'workerd') {
+          if (file !== undefined) {
+            throw new CliError('INVALID_OPTION', 'workerd runs the app from your wrangler config', {
+              suggestions: ['Drop the file argument. The entry is `main` in the wrangler config'],
+            })
+          }
+          const result = await runOnWorkerd({
+            path,
+            method: options.method || 'GET',
+            headers: parseHeaders(options.header),
+            ...(options.data === undefined ? {} : { body: options.data }),
+          })
+          await printResponse(result, path, options, doSaveFile, { runtime })
+          return
+        }
 
         if (runtime !== 'node') {
           const runnerResponse = await runInRuntime(runtime, resolveEntry(file), external, {

--- a/src/commands/request/runtime.test.ts
+++ b/src/commands/request/runtime.test.ts
@@ -24,9 +24,12 @@ describe('buildRunnerBody', () => {
     return parseRunnerOutput(stdout, MARKER, 'node')
   }
 
-  it('should send the request and print the response as a marker line', async () => {
-    const result = await run(
-      `{
+  it(
+    'should send the request and print the response as a marker line',
+    { timeout: 30000 },
+    async () => {
+      const result = await run(
+        `{
         request: async (req) => {
           const url = new URL(req.url)
           return new Response(JSON.stringify({ path: url.pathname, body: await req.text() }), {
@@ -35,27 +38,32 @@ describe('buildRunnerBody', () => {
           })
         },
       }`,
-      { path: '/echo', method: 'POST', headers: { 'x-in': 'abc' }, body: 'hello' }
-    )
+        { path: '/echo', method: 'POST', headers: { 'x-in': 'abc' }, body: 'hello' }
+      )
 
-    expect(result.status).toBe(201)
-    expect(result.headers['x-extra']).toBe('yes')
-    const body = JSON.parse(Buffer.from(result.bodyBase64, 'base64').toString('utf-8'))
-    expect(body).toEqual({ path: '/echo', body: 'hello' })
-  })
+      expect(result.status).toBe(201)
+      expect(result.headers['x-extra']).toBe('yes')
+      const body = JSON.parse(Buffer.from(result.bodyBase64, 'base64').toString('utf-8'))
+      expect(body).toEqual({ path: '/echo', body: 'hello' })
+    }
+  )
 
-  it('should fall back to fetch when the app has no request method', async () => {
-    const result = await run(
-      `{ fetch: (req) => new Response('from fetch', { headers: { 'x-h': req.headers.get('x-in') } }) }`,
-      { path: '/', method: 'GET', headers: { 'x-in': 'v' } }
-    )
+  it(
+    'should fall back to fetch when the app has no request method',
+    { timeout: 30000 },
+    async () => {
+      const result = await run(
+        `{ fetch: (req) => new Response('from fetch', { headers: { 'x-h': req.headers.get('x-in') } }) }`,
+        { path: '/', method: 'GET', headers: { 'x-in': 'v' } }
+      )
 
-    expect(result.status).toBe(200)
-    expect(result.headers['x-h']).toBe('v')
-    expect(Buffer.from(result.bodyBase64, 'base64').toString('utf-8')).toBe('from fetch')
-  })
+      expect(result.status).toBe(200)
+      expect(result.headers['x-h']).toBe('v')
+      expect(Buffer.from(result.bodyBase64, 'base64').toString('utf-8')).toBe('from fetch')
+    }
+  )
 
-  it('should carry a binary body as base64', async () => {
+  it('should carry a binary body as base64', { timeout: 30000 }, async () => {
     const result = await run(`{ fetch: () => new Response(new Uint8Array([0, 1, 254, 255])) }`, {
       path: '/',
       method: 'GET',

--- a/src/commands/request/runtime.ts
+++ b/src/commands/request/runtime.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'node:crypto'
 import type { AppEntry } from '../../utils/build.js'
 import { CliError } from '../../utils/output.js'
 
-export const RUNTIMES = ['node', 'bun', 'deno'] as const
+export const RUNTIMES = ['node', 'bun', 'deno', 'workerd'] as const
 export type Runtime = (typeof RUNTIMES)[number]
 
 export interface RunnerRequest {
@@ -69,7 +69,7 @@ interface RunnerCommand {
   install: string
 }
 
-const RUNNER_COMMANDS: Record<Exclude<Runtime, 'node'>, RunnerCommand> = {
+const RUNNER_COMMANDS: Record<'bun' | 'deno', RunnerCommand> = {
   bun: { bin: 'bun', args: ['run', '-'], install: 'Install Bun: https://bun.sh' },
   deno: { bin: 'deno', args: ['run', '--quiet', '-'], install: 'Install Deno: https://deno.com' },
 }
@@ -80,7 +80,7 @@ const RUNNER_COMMANDS: Record<Exclude<Runtime, 'node'>, RunnerCommand> = {
  * working directory.
  */
 export const runInRuntime = async (
-  runtime: Exclude<Runtime, 'node'>,
+  runtime: 'bun' | 'deno',
   entry: AppEntry,
   external: string[],
   request: RunnerRequest

--- a/src/commands/request/workerd.test.ts
+++ b/src/commands/request/workerd.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CliError } from '../../utils/output'
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+}))
+
+import { findWranglerConfig, runOnWorkerd } from './workerd'
+
+const getMockExistsSync = async () => vi.mocked((await import('node:fs')).existsSync)
+
+describe('findWranglerConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should pick the first existing candidate', async () => {
+    const existsSync = await getMockExistsSync()
+    existsSync.mockImplementation((path) => String(path).endsWith('wrangler.jsonc'))
+    expect(findWranglerConfig()).toBe('wrangler.jsonc')
+  })
+
+  it('should return undefined without a config', async () => {
+    const existsSync = await getMockExistsSync()
+    existsSync.mockReturnValue(false)
+    expect(findWranglerConfig()).toBeUndefined()
+  })
+})
+
+describe('runOnWorkerd', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should fail with WRANGLER_CONFIG_NOT_FOUND without a config', async () => {
+    const existsSync = await getMockExistsSync()
+    existsSync.mockReturnValue(false)
+    const promise = runOnWorkerd({ path: '/', method: 'GET', headers: {} })
+    await expect(promise).rejects.toThrowError(CliError)
+    await expect(promise).rejects.toMatchObject({ code: 'WRANGLER_CONFIG_NOT_FOUND' })
+  })
+
+  it('should fail with WRANGLER_NOT_FOUND when wrangler is not installed', async () => {
+    // This repo has a config (mocked) but no wrangler dependency
+    const existsSync = await getMockExistsSync()
+    existsSync.mockReturnValue(true)
+    const promise = runOnWorkerd({ path: '/', method: 'GET', headers: {} })
+    await expect(promise).rejects.toMatchObject({ code: 'WRANGLER_NOT_FOUND' })
+  })
+})

--- a/src/commands/request/workerd.ts
+++ b/src/commands/request/workerd.ts
@@ -1,0 +1,112 @@
+import { existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { CliError } from '../../utils/output.js'
+import type { RunnerRequest } from './runtime.js'
+
+export interface WorkerdResult {
+  status: number
+  headers: Record<string, string>
+  body: string
+  response: Response
+}
+
+interface StartedWorker {
+  fetch(url: string, init?: RequestInit): Promise<Response>
+  dispose(): Promise<void>
+}
+
+interface WranglerModule {
+  unstable_startWorker(options: {
+    config: string
+    dev: { logLevel: 'error' }
+  }): Promise<StartedWorker>
+}
+
+const CONFIG_CANDIDATES = ['wrangler.json', 'wrangler.jsonc', 'wrangler.toml']
+
+export const findWranglerConfig = (): string | undefined =>
+  CONFIG_CANDIDATES.find((file) => existsSync(join(process.cwd(), file)))
+
+/**
+ * wrangler is not a dependency of Hono CLI. It resolves from the user's
+ * project, which has it when the app targets Cloudflare.
+ */
+const loadWrangler = async (): Promise<WranglerModule> => {
+  const require = createRequire(join(process.cwd(), 'package.json'))
+  let resolved: string
+  try {
+    resolved = require.resolve('wrangler')
+  } catch {
+    throw new CliError('WRANGLER_NOT_FOUND', 'wrangler is not installed in this project', {
+      suggestions: ['Install it: npm install -D wrangler'],
+      docs: 'https://developers.cloudflare.com/workers/wrangler/',
+    })
+  }
+  return import(pathToFileURL(resolved).href)
+}
+
+const TIMEOUT_MS = 10000
+
+export const runOnWorkerd = async (request: RunnerRequest): Promise<WorkerdResult> => {
+  const config = findWranglerConfig()
+  if (!config) {
+    throw new CliError('WRANGLER_CONFIG_NOT_FOUND', 'No wrangler config found', {
+      suggestions: ['Create wrangler.jsonc with a main entry'],
+      docs: 'https://developers.cloudflare.com/workers/wrangler/configuration/',
+    })
+  }
+
+  const { unstable_startWorker } = await loadWrangler()
+  const worker = await unstable_startWorker({ config, dev: { logLevel: 'error' } })
+
+  let timeoutId: NodeJS.Timeout | undefined
+  try {
+    // When the runtime fails to start, worker.fetch() hangs and
+    // dispose() rejects with the root cause. The timeout uncovers it.
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(new CliError('RUNTIME_FAILED', `No response from workerd in ${TIMEOUT_MS / 1000}s`))
+      }, TIMEOUT_MS)
+    })
+    const response = await Promise.race([
+      worker.fetch(
+        `http://localhost${request.path.startsWith('/') ? request.path : `/${request.path}`}`,
+        {
+          method: request.method,
+          headers: request.headers,
+          ...(request.body === undefined ? {} : { body: request.body }),
+        }
+      ),
+      timeout,
+    ])
+
+    const headers: Record<string, string> = {}
+    response.headers.forEach((value, key) => {
+      headers[key] = value
+    })
+    const buffer = await response.clone().arrayBuffer()
+
+    return {
+      status: response.status,
+      headers,
+      body: new TextDecoder().decode(buffer),
+      response,
+    }
+  } catch (error) {
+    const cause = await worker.dispose().then(
+      () => undefined,
+      (disposeError: unknown) => disposeError
+    )
+    if (error instanceof CliError && cause instanceof Error) {
+      throw new CliError('RUNTIME_FAILED', `The app failed on workerd: ${cause.message}`, {
+        suggestions: ['Check the wrangler config and the error above'],
+      })
+    }
+    throw error
+  } finally {
+    clearTimeout(timeoutId)
+    await worker.dispose().catch(() => {})
+  }
+}


### PR DESCRIPTION
Add `workerd` to `--runtime` (part of #77). It starts the app with `unstable_startWorker()` from wrangler, sends one request, and prints the usual envelope. The local bindings from the wrangler config are real, so `c.env` works.

- wrangler is NOT a dependency of Hono CLI. It resolves from the user's project at run time. Missing wrangler is a `WRANGLER_NOT_FOUND` error with an install suggestion, missing config is `WRANGLER_CONFIG_NOT_FOUND`
- The entry is `main` in the wrangler config, so a file argument is an `INVALID_OPTION` error
- When workerd fails to start, `worker.fetch()` hangs — a timeout plus `dispose()` uncovers the root cause (the trick is from [workers-fetch](https://github.com/yusukebe/workers-fetch))
- Verified on a real project: `navigator.userAgent` returns `Cloudflare-Workers` and a `vars` binding comes through `c.env`

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code