### PR TITLE
feat: add benchmark command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ hono optimize
 
 # Generate static files from your Hono app
 hono ssg
+
+# Measure the performance of your Hono app
+hono benchmark
 ```
 
 ## Commands
@@ -50,6 +53,7 @@ Inspect and test:
 
 - `routes [file]` - Show routes of your Hono app
 - `request [file]` - Send request to Hono app using `app.request()`
+- `benchmark [file]` - Measure the performance of your Hono app
 
 Build:
 
@@ -211,6 +215,69 @@ The result is JSON with the shared envelope. A JSON response body is embedded as
 ```
 
 A binary response body becomes `"body": null` with `"binary": true` — save it with `-o`. Use `--plain` to print the raw body like curl.
+
+### `benchmark`
+
+Measure the performance of your Hono app. It is a micro benchmark of routing and handlers: `app.request()` is called directly, with no HTTP stack and no network. Each run happens in a fresh process, so results are comparable.
+
+```bash
+hono benchmark [file] [options]
+```
+
+**Arguments:**
+
+- `file` - Path to the Hono app file (TypeScript/JSX supported, optional)
+
+**Options:**
+
+- `-P, --path <path>` - benchmark only this path (can be used multiple times)
+- `--duration <ms>` - how long to measure each route (default: `500`)
+- `--warmup <count>` - requests before measuring (default: `30`)
+- `--hono <version-or-path>` - benchmark with this Hono instead (can be used multiple times)
+- `--plain` - human-readable output instead of JSON
+- `-e, --external <package>` - Mark package as external (can be used multiple times)
+
+**Examples:**
+
+```bash
+# Benchmark all GET routes
+hono benchmark
+
+# Benchmark one path
+hono benchmark -P /users
+
+# Compare two Hono versions with the same app
+hono benchmark --hono 4.12.3 --hono 4.13.0
+
+# Compare with a local Hono checkout
+hono benchmark --hono ../hono
+```
+
+**Output:**
+
+```json
+{
+  "ok": true,
+  "data": {
+    "results": [
+      {
+        "hono": "4.13.0",
+        "routes": [
+          {
+            "method": "GET",
+            "path": "/users",
+            "requests": 48210,
+            "rps": 96420,
+            "latency": { "avg": 0.01, "p50": 0.009, "p75": 0.011, "p99": 0.021 }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`--hono` runs the same app with another Hono: an npm version, or a path to a local package. Use it to compare Hono versions without setting up a benchmark environment. Latency is in milliseconds.
 
 ### `optimize`
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ hono benchmark [file] [options]
 **Options:**
 
 - `-P, --path <path>` - benchmark only this path (can be used multiple times)
+- `-X, --method <method>` - HTTP method for `-P` paths (default: `GET`)
+- `-d, --data <data>` - request body for `-P` paths (`@file` reads a file, `@-` reads stdin)
+- `-H, --header <header>` - custom headers for `-P` paths (can be used multiple times)
 - `--duration <ms>` - how long to measure each route (default: `500`)
 - `--warmup <count>` - requests before measuring (default: `30`)
 - `--hono <version-or-path>` - benchmark with this Hono instead (can be used multiple times)
@@ -245,6 +248,9 @@ hono benchmark
 
 # Benchmark one path
 hono benchmark -P /users
+
+# Benchmark a POST endpoint
+hono benchmark -P /users -X POST -d '{"name":"Alice"}' -H 'Content-Type: application/json'
 
 # Compare two Hono versions with the same app
 hono benchmark --hono 4.12.3 --hono 4.13.0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { agentContextCommand } from './commands/agent-context/index.js'
+import { benchmarkCommand } from './commands/benchmark/index.js'
 import { optimizeCommand } from './commands/optimize/index.js'
 import { requestCommand } from './commands/request/index.js'
 import { routesCommand } from './commands/routes/index.js'
@@ -27,6 +28,7 @@ optimizeCommand(program)
 requestCommand(program)
 routesCommand(program)
 ssgCommand(program)
+benchmarkCommand(program)
 agentContextCommand(program)
 
 program.parse()

--- a/src/commands/agent-context/document.ts
+++ b/src/commands/agent-context/document.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander'
 import type { CommandAgentContext } from '../../utils/agent-context.js'
 import { bullets, codeBlock, section, steps } from '../../utils/markdown.js'
+import { agentContext as benchmarkContext } from '../benchmark/index.js'
 import { agentContext as optimizeContext } from '../optimize/index.js'
 import { agentContext as requestContext } from '../request/index.js'
 import { agentContext as routesContext } from '../routes/index.js'
@@ -11,6 +12,7 @@ const contexts: Record<string, CommandAgentContext> = {
   request: requestContext,
   optimize: optimizeContext,
   ssg: ssgContext,
+  benchmark: benchmarkContext,
 }
 
 const commandDoc = (command: Command, context?: CommandAgentContext): string => {

--- a/src/commands/benchmark/engine.test.ts
+++ b/src/commands/benchmark/engine.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { execFile } from 'node:child_process'
+import { parseRunnerOutput } from '../request/runtime'
+import { buildBenchBody } from './engine'
+import type { RouteResult } from './engine'
+
+const MARKER = '__TEST_BENCH__'
+
+const execNode = (code: string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const child = execFile(process.execPath, ['--input-type=module'], (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr))
+        return
+      }
+      resolve(stdout)
+    })
+    child.stdin?.end(code)
+  })
+
+describe('buildBenchBody', () => {
+  it('should measure the targets and report the stats', { timeout: 30000 }, async () => {
+    const app = `const app = { fetch: () => new Response('ok') }`
+    const body = buildBenchBody(
+      [
+        { method: 'GET', path: '/' },
+        { method: 'GET', path: '/users/1' },
+      ],
+      { duration: 100, warmup: 5 },
+      MARKER
+    )
+    const stdout = await execNode(`${app}\n${body}`)
+    const { routes } = parseRunnerOutput<{ routes: RouteResult[] }>(stdout, MARKER, 'node')
+
+    expect(routes).toHaveLength(2)
+    for (const route of routes) {
+      expect(route.requests).toBeGreaterThan(0)
+      expect(route.rps).toBeGreaterThan(0)
+      expect(route.latency.p50).toBeGreaterThan(0)
+      expect(route.latency.p50).toBeLessThanOrEqual(route.latency.p99)
+    }
+    expect(routes[0].path).toBe('/')
+    expect(routes[1].path).toBe('/users/1')
+  })
+})

--- a/src/commands/benchmark/engine.ts
+++ b/src/commands/benchmark/engine.ts
@@ -9,6 +9,8 @@ import type { HonoSource } from './hono-source.js'
 export interface BenchTarget {
   method: string
   path: string
+  headers?: Record<string, string>
+  body?: string
 }
 
 export interface BenchOptions {
@@ -40,7 +42,11 @@ const routes = []
 for (const target of targets) {
   const send = async () => {
     const response = await handler(
-      new Request('http://localhost' + target.path, { method: target.method })
+      new Request('http://localhost' + target.path, {
+        method: target.method,
+        headers: target.headers ?? {},
+        ...(target.body === undefined ? {} : { body: target.body }),
+      })
     )
     await response.arrayBuffer()
   }

--- a/src/commands/benchmark/engine.ts
+++ b/src/commands/benchmark/engine.ts
@@ -1,0 +1,186 @@
+import * as esbuild from 'esbuild'
+import { execFile } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import type { AppEntry } from '../../utils/build.js'
+import { CliError } from '../../utils/output.js'
+import { parseRunnerOutput } from '../request/runtime.js'
+import type { HonoSource } from './hono-source.js'
+
+export interface BenchTarget {
+  method: string
+  path: string
+}
+
+export interface BenchOptions {
+  duration: number
+  warmup: number
+}
+
+export interface RouteResult {
+  method: string
+  path: string
+  requests: number
+  rps: number
+  latency: { avg: number; p50: number; p75: number; p99: number }
+}
+
+/**
+ * The bench body runs after the app import in a fresh process, so
+ * versions do not share JIT or GC state.
+ */
+export const buildBenchBody = (
+  targets: BenchTarget[],
+  options: BenchOptions,
+  marker: string
+): string => `
+const targets = ${JSON.stringify(targets)}
+const options = ${JSON.stringify(options)}
+const handler = typeof app.request === 'function' ? app.request.bind(app) : app.fetch.bind(app)
+const routes = []
+for (const target of targets) {
+  const send = async () => {
+    const response = await handler(
+      new Request('http://localhost' + target.path, { method: target.method })
+    )
+    await response.arrayBuffer()
+  }
+  for (let i = 0; i < options.warmup; i++) {
+    await send()
+  }
+  const times = []
+  const started = performance.now()
+  const until = started + options.duration
+  let now = started
+  while (now < until) {
+    const before = now
+    await send()
+    now = performance.now()
+    times.push(now - before)
+  }
+  times.sort((a, b) => a - b)
+  const total = now - started
+  const at = (q) => times[Math.min(times.length - 1, Math.floor(times.length * q))] ?? 0
+  const round = (value) => Math.round(value * 1000000) / 1000000
+  routes.push({
+    method: target.method,
+    path: target.path,
+    requests: times.length,
+    rps: Math.round((times.length / total) * 1000),
+    latency: {
+      avg: round(total / times.length),
+      p50: round(at(0.5)),
+      p75: round(at(0.75)),
+      p99: round(at(0.99)),
+    },
+  })
+}
+console.log(${JSON.stringify(marker)} + JSON.stringify({ routes }))
+`
+
+/**
+ * Bundle the app with the bench body. When the source has a
+ * resolveDir, `hono` imports resolve there instead of the project.
+ */
+export const buildBenchBundle = async (
+  entry: AppEntry,
+  external: string[],
+  source: HonoSource,
+  body: string
+): Promise<string> => {
+  const plugins: esbuild.Plugin[] = []
+  if (typeof entry !== 'string') {
+    plugins.push({
+      name: 'virtual-app',
+      setup(build) {
+        build.onResolve({ filter: /^virtual:app$/ }, () => ({
+          path: 'virtual:app',
+          namespace: 'virtual',
+        }))
+        build.onLoad({ filter: /^virtual:app$/, namespace: 'virtual' }, () => ({
+          contents: (entry as { code: string }).code,
+          loader: 'tsx',
+          resolveDir: process.cwd(),
+        }))
+      },
+    })
+  }
+  const aliasDir = source.resolveDir
+  if (aliasDir) {
+    plugins.push({
+      name: 'hono-alias',
+      setup(build) {
+        build.onResolve({ filter: /^hono($|\/)/ }, async (args) => {
+          if (args.pluginData === 'hono-alias') {
+            return undefined
+          }
+          return build.resolve(args.path, {
+            kind: 'import-statement',
+            resolveDir: aliasDir,
+            pluginData: 'hono-alias',
+          })
+        })
+      },
+    })
+  }
+
+  const importSource = typeof entry === 'string' ? entry : 'virtual:app'
+  const result = await esbuild.build({
+    stdin: {
+      contents: `import app from ${JSON.stringify(importSource)}\n${body}`,
+      resolveDir: process.cwd(),
+      loader: 'tsx',
+      sourcefile: '__bench__.tsx',
+    },
+    bundle: true,
+    write: false,
+    format: 'esm',
+    target: 'esnext',
+    platform: 'node',
+    jsx: 'automatic',
+    jsxImportSource: 'hono/jsx',
+    external,
+    plugins,
+  })
+  return result.outputFiles[0].text
+}
+
+export const runBench = async (
+  entry: AppEntry,
+  external: string[],
+  source: HonoSource,
+  targets: BenchTarget[],
+  options: BenchOptions
+): Promise<RouteResult[]> => {
+  const marker = `__HONO_CLI_BENCH_${randomUUID()}__`
+  const body = buildBenchBody(targets, options, marker)
+  const code = await buildBenchBundle(entry, external, source, body)
+  const stdout = await execNode(code)
+  return parseRunnerOutput<{ routes: RouteResult[] }>(stdout, marker, 'node').routes
+}
+
+const execNode = (code: string): Promise<string> =>
+  new Promise((resolvePromise, reject) => {
+    const child = execFile(
+      process.execPath,
+      ['--input-type=module'],
+      { maxBuffer: 64 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (stderr) {
+          process.stderr.write(stderr)
+        }
+        if (error) {
+          if (stdout) {
+            process.stderr.write(stdout)
+          }
+          reject(
+            new CliError('BENCH_FAILED', 'The benchmark failed', {
+              suggestions: ['Check the error output above'],
+            })
+          )
+          return
+        }
+        resolvePromise(stdout)
+      }
+    )
+    child.stdin?.end(code)
+  })

--- a/src/commands/benchmark/hono-source.test.ts
+++ b/src/commands/benchmark/hono-source.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { projectHonoSource, resolveHonoSource } from './hono-source'
+
+describe('projectHonoSource', () => {
+  it('should label with the installed hono version', () => {
+    const source = projectHonoSource()
+    expect(source.label).toMatch(/^\d+\.\d+\.\d+/)
+    expect(source.resolveDir).toBeUndefined()
+  })
+})
+
+describe('resolveHonoSource', () => {
+  it('should use a local package directory', async () => {
+    const source = await resolveHonoSource('./node_modules/hono')
+    expect(source.label).toContain('(./node_modules/hono)')
+    expect(source.resolveDir).toBeDefined()
+    source.cleanup?.()
+  })
+
+  it('should fail with HONO_SOURCE_NOT_FOUND for a missing path', async () => {
+    await expect(resolveHonoSource('./no-such-dir')).rejects.toMatchObject({
+      code: 'HONO_SOURCE_NOT_FOUND',
+    })
+  })
+
+  it('should install a published version with npm', { timeout: 0 }, async () => {
+    const source = await resolveHonoSource('4.9.10')
+    expect(source.label).toBe('4.9.10')
+    expect(source.resolveDir).toBeDefined()
+    source.cleanup?.()
+  })
+})

--- a/src/commands/benchmark/hono-source.ts
+++ b/src/commands/benchmark/hono-source.ts
@@ -1,0 +1,85 @@
+import { execFile } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { CliError } from '../../utils/output.js'
+
+/**
+ * A Hono to benchmark against. `resolveDir` makes `hono` imports
+ * resolve there instead of the project. Undefined means the project's
+ * own Hono.
+ */
+export interface HonoSource {
+  label: string
+  resolveDir?: string
+  cleanup?: () => void
+}
+
+export const projectHonoSource = (): HonoSource => {
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(join(process.cwd(), 'node_modules', 'hono', 'package.json'), 'utf-8')
+    )
+    return { label: packageJson.version }
+  } catch {
+    return { label: 'project' }
+  }
+}
+
+export const resolveHonoSource = async (spec: string): Promise<HonoSource> => {
+  if (spec.startsWith('.') || spec.startsWith('/')) {
+    return pathSource(spec)
+  }
+  return npmSource(spec)
+}
+
+const pathSource = (spec: string): HonoSource => {
+  const packageDir = resolve(process.cwd(), spec)
+  const packageJsonPath = join(packageDir, 'package.json')
+  if (!existsSync(packageJsonPath)) {
+    throw new CliError('HONO_SOURCE_NOT_FOUND', `No package found at ${spec}`, {
+      suggestions: ['Pass a path to a hono package directory, or a version like 4.13.0'],
+    })
+  }
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
+  // A local checkout resolves through a wrapper dir with a node_modules link
+  const dir = mkdtempSync(join(tmpdir(), 'hono-cli-bench-'))
+  const nodeModules = join(dir, 'node_modules')
+  mkdirSync(nodeModules, { recursive: true })
+  symlinkSync(packageDir, join(nodeModules, 'hono'), 'dir')
+  return {
+    label: `${packageJson.version} (${spec})`,
+    resolveDir: dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  }
+}
+
+const npmSource = async (spec: string): Promise<HonoSource> => {
+  const dir = mkdtempSync(join(tmpdir(), 'hono-cli-bench-'))
+  await new Promise<void>((resolvePromise, reject) => {
+    execFile(
+      'npm',
+      ['install', `hono@${spec}`, '--prefix', dir, '--no-audit', '--no-fund', '--silent'],
+      (error) => {
+        if (error) {
+          rmSync(dir, { recursive: true, force: true })
+          reject(
+            new CliError('HONO_INSTALL_FAILED', `Failed to install hono@${spec}`, {
+              suggestions: ['Check the version. Published versions: npm view hono versions'],
+            })
+          )
+          return
+        }
+        resolvePromise()
+      }
+    )
+  })
+  const packageJson = JSON.parse(
+    readFileSync(join(dir, 'node_modules', 'hono', 'package.json'), 'utf-8')
+  )
+  return {
+    label: packageJson.version,
+    resolveDir: dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  }
+}

--- a/src/commands/benchmark/index.test.ts
+++ b/src/commands/benchmark/index.test.ts
@@ -120,6 +120,46 @@ describe('benchmarkCommand', () => {
     ])
   })
 
+  it('should benchmark a POST path with a body and headers', async () => {
+    setupBasicMocks(new Hono())
+
+    await program.parseAsync([
+      'node',
+      'test',
+      'benchmark',
+      '-P',
+      '/users',
+      '-X',
+      'POST',
+      '-d',
+      '{"name":"Alice"}',
+      '-H',
+      'Content-Type: application/json',
+      'test-app.js',
+    ])
+
+    const [, , , targets] = mockRunBench.mock.calls[0]
+    expect(targets).toEqual([
+      {
+        method: 'POST',
+        path: '/users',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{"name":"Alice"}',
+      },
+    ])
+  })
+
+  it('should reject -X without -P', async () => {
+    setupBasicMocks(new Hono())
+
+    await program.parseAsync(['node', 'test', 'benchmark', '-X', 'POST', 'test-app.js'])
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(parsed.ok).toBe(false)
+    expect(parsed.error.code).toBe('INVALID_OPTION')
+    process.exitCode = undefined
+  })
+
   it('should fail with NO_ROUTES when the app has no GET routes', async () => {
     const app = new Hono()
     app.post('/users', (c) => c.json({}))

--- a/src/commands/benchmark/index.test.ts
+++ b/src/commands/benchmark/index.test.ts
@@ -1,0 +1,147 @@
+import { Command } from 'commander'
+import { Hono } from 'hono'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock dependencies
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  realpathSync: vi.fn(),
+  readFileSync: vi.fn(),
+}))
+
+vi.mock('node:path', () => ({
+  resolve: vi.fn(),
+  join: vi.fn((...parts: string[]) => parts.join('/')),
+}))
+
+vi.mock('../../utils/build.js', () => ({
+  buildAndImportApp: vi.fn(),
+}))
+
+vi.mock('./engine.js', async (importOriginal) => {
+  const original = await importOriginal<typeof EngineModule>()
+  return { ...original, runBench: vi.fn() }
+})
+
+import type * as EngineModule from './engine.js'
+import { benchmarkCommand } from './index.js'
+
+describe('benchmarkCommand', () => {
+  let program: Command
+  const spyOnLog = () => vi.spyOn(console, 'log').mockImplementation(() => {})
+  let consoleLogSpy: ReturnType<typeof spyOnLog>
+  let consoleErrorSpy: ReturnType<typeof spyOnLog>
+
+  const getMockModules = async () => ({
+    existsSync: vi.mocked((await import('node:fs')).existsSync),
+    realpathSync: vi.mocked((await import('node:fs')).realpathSync),
+    readFileSync: vi.mocked((await import('node:fs')).readFileSync),
+    resolve: vi.mocked((await import('node:path')).resolve),
+  })
+  const getMockBuildAndImportApp = async () =>
+    vi.mocked((await import('../../utils/build.js')).buildAndImportApp)
+  const getMockRunBench = async () => vi.mocked((await import('./engine.js')).runBench)
+
+  let mockModules: Awaited<ReturnType<typeof getMockModules>>
+  let mockBuildAndImportApp: Awaited<ReturnType<typeof getMockBuildAndImportApp>>
+  let mockRunBench: Awaited<ReturnType<typeof getMockRunBench>>
+
+  async function* createBuildIterator(app: Hono): AsyncGenerator<Hono> {
+    yield app
+  }
+
+  const routeResult = {
+    method: 'GET',
+    path: '/',
+    requests: 100,
+    rps: 1000,
+    latency: { avg: 0.1, p50: 0.1, p75: 0.1, p99: 0.2 },
+  }
+
+  const setupBasicMocks = (app: Hono) => {
+    mockModules.existsSync.mockReturnValue(true)
+    mockModules.realpathSync.mockReturnValue('test-app.js')
+    mockModules.readFileSync.mockReturnValue('{"version":"4.99.0"}')
+    mockModules.resolve.mockImplementation((cwd: string, path: string) => `${cwd}/${path}`)
+    mockBuildAndImportApp.mockReturnValue(createBuildIterator(app))
+    mockRunBench.mockResolvedValue([routeResult])
+  }
+
+  beforeEach(async () => {
+    program = new Command()
+    benchmarkCommand(program)
+    consoleLogSpy = spyOnLog()
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    mockModules = await getMockModules()
+    mockBuildAndImportApp = await getMockBuildAndImportApp()
+    mockRunBench = await getMockRunBench()
+
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+    vi.restoreAllMocks()
+  })
+
+  it('should benchmark the GET routes of the app', async () => {
+    const app = new Hono()
+    app.use(async (_c, next) => {
+      await next()
+    })
+    app.get('/', (c) => c.text('Hi'))
+    app.get('/users/:id', (c) => c.json({}))
+    app.post('/users', (c) => c.json({}))
+    setupBasicMocks(app)
+
+    await program.parseAsync(['node', 'test', 'benchmark', 'test-app.js'])
+
+    const [, , , targets] = mockRunBench.mock.calls[0]
+    expect(targets).toEqual([
+      { method: 'GET', path: '/' },
+      { method: 'GET', path: '/users/1' },
+    ])
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(parsed.ok).toBe(true)
+    expect(parsed.data.results).toEqual([{ hono: '4.99.0', routes: [routeResult] }])
+  })
+
+  it('should benchmark only the paths from -P', async () => {
+    setupBasicMocks(new Hono())
+
+    await program.parseAsync(['node', 'test', 'benchmark', '-P', '/a', '-P', '/b', 'test-app.js'])
+
+    const [, , , targets] = mockRunBench.mock.calls[0]
+    expect(targets).toEqual([
+      { method: 'GET', path: '/a' },
+      { method: 'GET', path: '/b' },
+    ])
+  })
+
+  it('should fail with NO_ROUTES when the app has no GET routes', async () => {
+    const app = new Hono()
+    app.post('/users', (c) => c.json({}))
+    setupBasicMocks(app)
+
+    await program.parseAsync(['node', 'test', 'benchmark', 'test-app.js'])
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(parsed.ok).toBe(false)
+    expect(parsed.error.code).toBe('NO_ROUTES')
+    expect(process.exitCode).toBe(1)
+    process.exitCode = undefined
+  })
+
+  it('should reject an invalid duration', async () => {
+    setupBasicMocks(new Hono())
+
+    await program.parseAsync(['node', 'test', 'benchmark', '--duration', 'zero', 'test-app.js'])
+
+    const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(parsed.ok).toBe(false)
+    expect(parsed.error.code).toBe('INVALID_OPTION')
+    process.exitCode = undefined
+  })
+})

--- a/src/commands/benchmark/index.ts
+++ b/src/commands/benchmark/index.ts
@@ -2,7 +2,7 @@ import type { Command } from 'commander'
 import { inspectRoutes } from 'hono/dev'
 import type { CommandAgentContext } from '../../utils/agent-context.js'
 import { buildAndImportApp } from '../../utils/build.js'
-import { getBuildIterator, resolveEntry } from '../../utils/load-app.js'
+import { getBuildIterator, resolveData, resolveEntry } from '../../utils/load-app.js'
 import { CliError, handleErrors, printResult } from '../../utils/output.js'
 import type { BenchTarget, RouteResult } from './engine.js'
 import { runBench } from './engine.js'
@@ -16,6 +16,7 @@ export const agentContext: CommandAgentContext = {
   examples: [
     'hono benchmark',
     'hono benchmark -P /users',
+    `hono benchmark -P /users -X POST -d '{"name":"Alice"}'`,
     'hono benchmark --hono 4.12.3 --hono 4.13.0',
     'hono benchmark --hono ../hono',
   ],
@@ -23,6 +24,7 @@ export const agentContext: CommandAgentContext = {
     'This is a micro benchmark of routing and handlers. It calls app.request() directly — no HTTP stack, no network.',
     'Each run happens in a fresh process, so results are comparable.',
     '--hono benchmarks the same app with another Hono: an npm version, or a path to a local checkout. Use it to compare Hono versions without touching the project.',
+    '-X, -d, and -H set the method, body, and headers for -P paths. The route sweep stays GET only.',
     'Latency is in milliseconds.',
   ],
 }
@@ -32,6 +34,9 @@ const collect = (value: string, previous: string[]): string[] =>
 
 interface BenchmarkOptions {
   path: string[]
+  method: string
+  data?: string
+  header: string[]
   duration: string
   warmup: string
   hono: string[]
@@ -49,6 +54,14 @@ export function benchmarkCommand(program: Command) {
       'benchmark only this path (can be used multiple times)',
       collect,
       []
+    )
+    .option('-X, --method <method>', 'HTTP method for -P paths', 'GET')
+    .option('-d, --data <data>', 'request body for -P paths (@file reads a file, @- reads stdin)')
+    .option(
+      '-H, --header <header>',
+      'custom headers for -P paths (can be used multiple times)',
+      collect,
+      [] as string[]
     )
     .option('--duration <ms>', 'how long to measure each route', '500')
     .option('--warmup <count>', 'requests before measuring', '30')
@@ -75,9 +88,21 @@ export function benchmarkCommand(program: Command) {
           })
         }
 
+        const method = (options.method || 'GET').toUpperCase()
+        if (
+          options.path.length === 0 &&
+          (method !== 'GET' || options.data || options.header.length > 0)
+        ) {
+          throw new CliError('INVALID_OPTION', '-X, -d, and -H work only with -P paths', {
+            suggestions: [
+              'Pass the path too: hono benchmark -P /users -X POST -d \'{"name":"Alice"}\'',
+            ],
+          })
+        }
+
         const external = options.external || []
         const entry = resolveEntry(file)
-        const targets = await collectTargets(file, entry, options.path, external)
+        const targets = await collectTargets(file, entry, options, method, external)
 
         const sources: HonoSource[] = []
         try {
@@ -113,11 +138,25 @@ export function benchmarkCommand(program: Command) {
 const collectTargets = async (
   file: string | undefined,
   entry: ReturnType<typeof resolveEntry>,
-  paths: string[],
+  options: BenchmarkOptions,
+  method: string,
   external: string[]
 ): Promise<BenchTarget[]> => {
-  if (paths.length > 0) {
-    return paths.map((path) => ({ method: 'GET', path }))
+  if (options.path.length > 0) {
+    const headers: Record<string, string> = {}
+    for (const header of options.header) {
+      const [key, value] = header.split(':', 2)
+      if (key && value) {
+        headers[key.trim()] = value.trim()
+      }
+    }
+    const body = resolveData(options.data)
+    return options.path.map((path) => ({
+      method,
+      path,
+      ...(Object.keys(headers).length > 0 ? { headers } : {}),
+      ...(body === undefined ? {} : { body }),
+    }))
   }
 
   // Enumerate the GET routes of the app, like `hono routes`

--- a/src/commands/benchmark/index.ts
+++ b/src/commands/benchmark/index.ts
@@ -25,6 +25,7 @@ export const agentContext: CommandAgentContext = {
     'Each run happens in a fresh process, so results are comparable.',
     '--hono benchmarks the same app with another Hono: an npm version, or a path to a local checkout. Use it to compare Hono versions without touching the project.',
     '-X, -d, and -H set the method, body, and headers for -P paths. The route sweep stays GET only.',
+    'A few percent of difference is noise. To compare, run it more than once and check the difference repeats.',
     'Latency is in milliseconds.',
   ],
 }

--- a/src/commands/benchmark/index.ts
+++ b/src/commands/benchmark/index.ts
@@ -1,0 +1,167 @@
+import type { Command } from 'commander'
+import { inspectRoutes } from 'hono/dev'
+import type { CommandAgentContext } from '../../utils/agent-context.js'
+import { buildAndImportApp } from '../../utils/build.js'
+import { getBuildIterator, resolveEntry } from '../../utils/load-app.js'
+import { CliError, handleErrors, printResult } from '../../utils/output.js'
+import type { BenchTarget, RouteResult } from './engine.js'
+import { runBench } from './engine.js'
+import type { HonoSource } from './hono-source.js'
+import { projectHonoSource, resolveHonoSource } from './hono-source.js'
+
+export const agentContext: CommandAgentContext = {
+  output:
+    '{ "results": [{ "hono": "4.13.0", "routes": [{ "method": "GET", "path": "/users", "requests": 48210, "rps": 96420, "latency": { "avg": 0.01, "p50": 0.009, "p75": 0.011, "p99": 0.021 } }] }] }',
+  errors: ['ENTRY_NOT_FOUND', 'INVALID_APP', 'NO_ROUTES', 'HONO_INSTALL_FAILED', 'BENCH_FAILED'],
+  examples: [
+    'hono benchmark',
+    'hono benchmark -P /users',
+    'hono benchmark --hono 4.12.3 --hono 4.13.0',
+    'hono benchmark --hono ../hono',
+  ],
+  notes: [
+    'This is a micro benchmark of routing and handlers. It calls app.request() directly — no HTTP stack, no network.',
+    'Each run happens in a fresh process, so results are comparable.',
+    '--hono benchmarks the same app with another Hono: an npm version, or a path to a local checkout. Use it to compare Hono versions without touching the project.',
+    'Latency is in milliseconds.',
+  ],
+}
+
+const collect = (value: string, previous: string[]): string[] =>
+  previous ? [...previous, value] : [value]
+
+interface BenchmarkOptions {
+  path: string[]
+  duration: string
+  warmup: string
+  hono: string[]
+  plain: boolean
+  external?: string[]
+}
+
+export function benchmarkCommand(program: Command) {
+  program
+    .command('benchmark')
+    .description('Measure the performance of your Hono app')
+    .argument('[file]', 'Path to the Hono app file')
+    .option(
+      '-P, --path <path>',
+      'benchmark only this path (can be used multiple times)',
+      collect,
+      []
+    )
+    .option('--duration <ms>', 'how long to measure each route', '500')
+    .option('--warmup <count>', 'requests before measuring', '30')
+    .option(
+      '--hono <version-or-path>',
+      'benchmark with this Hono instead (can be used multiple times)',
+      collect,
+      [] as string[]
+    )
+    .option('--plain', 'human-readable output instead of JSON', false)
+    .option(
+      '-e, --external <package>',
+      'Mark package as external (can be used multiple times)',
+      collect,
+      [] as string[]
+    )
+    .action(
+      handleErrors(async (file: string | undefined, options: BenchmarkOptions) => {
+        const duration = Number(options.duration)
+        const warmup = Number(options.warmup)
+        if (!Number.isFinite(duration) || duration <= 0 || !Number.isFinite(warmup) || warmup < 0) {
+          throw new CliError('INVALID_OPTION', 'Invalid --duration or --warmup', {
+            suggestions: ['Pass positive numbers: --duration 500 --warmup 30'],
+          })
+        }
+
+        const external = options.external || []
+        const entry = resolveEntry(file)
+        const targets = await collectTargets(file, entry, options.path, external)
+
+        const sources: HonoSource[] = []
+        try {
+          if (options.hono.length === 0) {
+            sources.push(projectHonoSource())
+          } else {
+            for (const spec of options.hono) {
+              sources.push(await resolveHonoSource(spec))
+            }
+          }
+
+          const results: { hono: string; routes: RouteResult[] }[] = []
+          for (const source of sources) {
+            console.error(`Benchmarking with hono ${source.label} ...`)
+            const routes = await runBench(entry, external, source, targets, { duration, warmup })
+            results.push({ hono: source.label, routes })
+          }
+
+          if (options.plain) {
+            printPlainResults(results)
+            return
+          }
+          printResult({ results })
+        } finally {
+          for (const source of sources) {
+            source.cleanup?.()
+          }
+        }
+      })
+    )
+}
+
+const collectTargets = async (
+  file: string | undefined,
+  entry: ReturnType<typeof resolveEntry>,
+  paths: string[],
+  external: string[]
+): Promise<BenchTarget[]> => {
+  if (paths.length > 0) {
+    return paths.map((path) => ({ method: 'GET', path }))
+  }
+
+  // Enumerate the GET routes of the app, like `hono routes`
+  const buildIterator =
+    typeof entry === 'string'
+      ? getBuildIterator(file, false, external)
+      : buildAndImportApp(entry, { external: ['@hono/node-server', ...external] })
+  const app = (await buildIterator.next()).value
+  if (!app || !Array.isArray(app.routes)) {
+    throw new CliError('INVALID_APP', 'The app does not expose routes', {
+      suggestions: ['Export the Hono instance as the default export'],
+      docs: 'https://hono.dev/docs/api/hono',
+    })
+  }
+
+  const seen = new Set<string>()
+  const targets: BenchTarget[] = []
+  for (const route of inspectRoutes(app)) {
+    if (route.isMiddleware || route.method !== 'GET' || route.path.includes('*')) {
+      continue
+    }
+    const path = route.path.replace(/:[^/]+/g, '1')
+    if (seen.has(path)) {
+      continue
+    }
+    seen.add(path)
+    targets.push({ method: 'GET', path })
+  }
+  if (targets.length === 0) {
+    throw new CliError('NO_ROUTES', 'No GET routes to benchmark', {
+      suggestions: ['Pass a path: hono benchmark -P /'],
+    })
+  }
+  return targets
+}
+
+const printPlainResults = (results: { hono: string; routes: RouteResult[] }[]): void => {
+  for (const result of results) {
+    console.log(`[hono ${result.hono}]`)
+    const maxPathLength = Math.max(...result.routes.map(({ path }) => path.length), 0)
+    for (const route of result.routes) {
+      console.log(
+        `  ${route.method} ${route.path.padEnd(maxPathLength)}  ${String(route.rps).padStart(8)} rps  p50 ${route.latency.p50}ms  p99 ${route.latency.p99}ms`
+      )
+    }
+  }
+}

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -1,9 +1,8 @@
 import type { Command } from 'commander'
 import type { Hono } from 'hono'
-import { readFileSync } from 'node:fs'
 import type { CommandAgentContext } from '../../utils/agent-context.js'
 import { getFilenameFromPath, saveFile } from '../../utils/file.js'
-import { getBuildIterator, readStdin, resolveEntry } from '../../utils/load-app.js'
+import { getBuildIterator, resolveData, resolveEntry } from '../../utils/load-app.js'
 import { CliError, handleErrors, printResult } from '../../utils/output.js'
 import type { Runtime } from './runtime.js'
 import { RUNTIMES, runInRuntime } from './runtime.js'
@@ -263,16 +262,6 @@ const parseHeaders = (header: string[] | undefined): Record<string, string> => {
     }
   }
   return headers
-}
-
-const resolveData = (data: string | undefined): string | undefined => {
-  if (data === undefined || !data.startsWith('@')) {
-    return data
-  }
-  if (data === '@-') {
-    return readStdin()
-  }
-  return readFileSync(data.slice(1), 'utf-8')
 }
 
 export async function executeRequest(

--- a/src/commands/request/runtime.ts
+++ b/src/commands/request/runtime.ts
@@ -149,11 +149,11 @@ const execRunner = (runtime: string, command: RunnerCommand, code: string): Prom
     child.stdin?.end(code)
   })
 
-export const parseRunnerOutput = (
+export const parseRunnerOutput = <T = RunnerResponse>(
   stdout: string,
   marker: string,
   runtime: string
-): RunnerResponse => {
+): T => {
   const lines = stdout.split('\n')
   const resultLine = lines.find((line) => line.includes(marker))
   const logs = lines.filter((line) => line !== resultLine && line.length > 0)

--- a/src/utils/load-app.ts
+++ b/src/utils/load-app.ts
@@ -88,3 +88,17 @@ export const wrapCode = (code: string): string => {
   }
   return `import { Hono } from 'hono'\nconst app = new Hono()\n${code}\nexport default app\n`
 }
+
+/**
+ * Resolve a request body option: `@file` reads a file, `@-` reads
+ * stdin, anything else is the body itself.
+ */
+export const resolveData = (data: string | undefined): string | undefined => {
+  if (data === undefined || !data.startsWith('@')) {
+    return data
+  }
+  if (data === '@-') {
+    return readStdin()
+  }
+  return readFileSync(data.slice(1), 'utf-8')
+}


### PR DESCRIPTION
Add `hono benchmark`, the last command of #77. It is a micro benchmark of routing and handlers: `app.request()` is called directly, no HTTP stack. Each run happens in a fresh process, so results are comparable.

- Default: benchmark every GET route of the app (`:param` becomes `1`). `-P` limits the paths
- `--hono <version-or-path>` benchmarks the same app with another Hono: an npm version (installed to a temp dir, resolved by an esbuild plugin) or a path to a local checkout. One command compares 4.12.3 vs 4.13.0, or the dev build — no benchmark environment to set up
- The measuring loop is hand-written (warmup → timed loop → p50/p75/p99/avg/rps). No new dependencies
- Output is the shared envelope, `--plain` prints one line per route

```bash
hono benchmark --hono 4.12.3 --hono 4.13.0
```

Verified on a real project: comparing 4.9.10 and 4.13.0 across three routes works, and a version diff shows up in rps.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code