### PR TITLE
docs: order the usage block like the groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ hono routes
 # Send request to Hono app
 hono request
 
+# Measure the performance of your Hono app
+hono benchmark
+
 # Build an optimized Hono app
 hono optimize
 
 # Generate static files from your Hono app
 hono ssg
-
-# Measure the performance of your Hono app
-hono benchmark
 ```
 
 ## Commands


### PR DESCRIPTION
Follow-up to #103. The usage block had `benchmark` at the end. Move it next to `request`, like the command groups.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code