### PR TITLE
ci: publish a prerelease to the next tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,10 @@ jobs:
       - run: pnpm run build
 
       - name: Publish to npm
-        run: npm stage publish --provenance --access public
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          if [[ "$version" == *-* ]]; then
+            npm stage publish --provenance --access public --tag next
+          else
+            npm stage publish --provenance --access public
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,11 @@ Rank findings by severity: `blocker` / `bug` / `risk` / `nit`.
    package on npm with staged publishing
 3. A maintainer approves the staged package on npmjs.com (needs 2FA)
 
+A prerelease (a version like `0.2.0-next.0`) publishes to the `next`
+dist-tag, so `latest` does not move. Users opt in with
+`npm install @hono/cli@next`. Release it from the `next` branch with
+`pnpm run release --any-branch`.
+
 ## Hono Documentation
 
 Need Hono details? Fetch <https://hono.dev/llms.txt> to find the right


### PR DESCRIPTION
Prepare for a 0.2 prerelease. When the version is a prerelease (like `0.2.0-next.0`), the release workflow stages it with `--tag next`, so `latest` stays on 0.1.x. Users opt in with `npm install @hono/cli@next`. The release steps in AGENTS.md explain it.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code