### PR TITLE
chore: order the help like the README

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,11 +24,11 @@ program
   .addHelpText('after', "\nFor coding agents: run 'hono agent-context' and follow it.")
 
 // Register commands
-optimizeCommand(program)
-requestCommand(program)
-routesCommand(program)
-ssgCommand(program)
-benchmarkCommand(program)
 agentContextCommand(program)
+routesCommand(program)
+requestCommand(program)
+benchmarkCommand(program)
+optimizeCommand(program)
+ssgCommand(program)
 
 program.parse()


### PR DESCRIPTION
Register the commands in the same order as the README groups, so `--help` and `agent-context` list them as: agent-context, routes, request, benchmark, optimize, ssg.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code