### PR TITLE
docs: note the 0.2 prerelease install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ It's not a `create-*` command and not a Vite wrapper. It loads your Hono app dir
 
 ## Installation
 
+> [!NOTE]
+> This is the 0.2 prerelease. Try it with `npm install -g @hono/cli@next`. The stable 0.1 is on `latest`.
+
 Install it in your project. Coding agents find it in `package.json`:
 
 ```bash


### PR DESCRIPTION
Tell readers of the `next` branch how to try 0.2: `npm install -g @hono/cli@next`. Remove this note at the 0.2.0 release.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code