### PR TITLE
feat(request): suggest --trace on a 404 result

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The result is JSON with the shared envelope. A JSON response body is embedded as
 }
 ```
 
-A binary response body becomes `"body": null` with `"binary": true` — save it with `-o`. Use `--plain` to print the raw body like curl.
+A binary response body becomes `"body": null` with `"binary": true` — save it with `-o`. Use `--plain` to print the raw body like curl. A 404 result includes a suggestion to run `--trace`.
 
 ### `benchmark`
 

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -1246,6 +1246,7 @@ describe('requestCommand', () => {
       await program.parseAsync(['node', 'test', 'request', '-P', '/exists', 'test-app.js'])
       expect(JSON.parse(consoleLogSpy.mock.calls[0][0]).data.suggestions).toBeUndefined()
 
+      setupBasicMocks('test-app.js', mockApp)
       await program.parseAsync([
         'node',
         'test',

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -1222,4 +1222,40 @@ describe('requestCommand', () => {
       process.exitCode = undefined
     })
   })
+
+  describe('404 trace suggestion', () => {
+    it('should suggest --trace on a 404 response', async () => {
+      const mockApp = new Hono()
+      mockApp.get('/exists', (c) => c.text('ok'))
+      setupBasicMocks('test-app.js', mockApp)
+
+      await program.parseAsync(['node', 'test', 'request', '-P', '/missing', 'test-app.js'])
+
+      const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
+      expect(parsed.data.status).toBe(404)
+      expect(parsed.data.suggestions).toEqual([
+        'See which routes matched: hono request -P /missing --trace',
+      ])
+    })
+
+    it('should not suggest --trace on a success or when tracing already', async () => {
+      const mockApp = new Hono()
+      mockApp.get('/exists', (c) => c.text('ok'))
+      setupBasicMocks('test-app.js', mockApp)
+
+      await program.parseAsync(['node', 'test', 'request', '-P', '/exists', 'test-app.js'])
+      expect(JSON.parse(consoleLogSpy.mock.calls[0][0]).data.suggestions).toBeUndefined()
+
+      await program.parseAsync([
+        'node',
+        'test',
+        'request',
+        '-P',
+        '/missing',
+        '--trace',
+        'test-app.js',
+      ])
+      expect(JSON.parse(consoleLogSpy.mock.calls[1][0]).data.suggestions).toBeUndefined()
+    })
+  })
 })

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -33,7 +33,7 @@ export const agentContext: CommandAgentContext = {
     'Pass - as the file to read the app code from stdin. `app` is predefined and exported for you — write only routes. Code with its own `export default` is used as-is.',
     '-d @file reads the body from a file, -d @- reads it from stdin.',
     '--runtime runs the app on bun, deno, or workerd instead of Node.js. bun and deno must be installed. workerd starts the app with the wrangler config of the project, so the local bindings (c.env) are real — it needs wrangler installed and no file argument.',
-    '--trace adds matchedRoutes to the output: which middleware and handler matched, and which one responded. Use it to debug an unexpected response.',
+    '--trace adds matchedRoutes to the output: which middleware and handler matched, and which one responded. Use it to debug an unexpected response. A 404 result includes a suggestion to run it.',
     'A JSON response body is embedded as an object. A binary body becomes null with "binary": true — save it with -o.',
   ],
 }
@@ -193,12 +193,19 @@ const printResponse = async (
     return
   }
 
+  // Agents rarely discover --trace on their own. A 404 is the moment
+  // it helps, so point at it right there.
+  const suggestTrace = result.status === 404 && !options.trace && options.runtime === 'node'
+
   printResult({
     status: result.status,
     headers: result.headers,
     body: isBinaryData ? null : parseBody(result.body, contentType),
     ...(isBinaryData ? { binary: true } : {}),
     ...(savedTo ? { savedTo } : {}),
+    ...(suggestTrace
+      ? { suggestions: [`See which routes matched: hono request -P ${path} --trace`] }
+      : {}),
     ...extra,
   })
 }


### PR DESCRIPTION
The first agent-dx experiments showed that agents use `request` heavily but never discover `--trace`, even on a 404 debugging task (0 of 20 runs). Agents do follow suggestions in the output, so put the pointer where they already are:

```json
{
  "ok": true,
  "data": {
    "status": 404,
    "body": "404 Not Found",
    "suggestions": ["See which routes matched: hono request -P /nope --trace"]
  }
}
```

Only on a 404, only on the node runtime, and not when tracing already. Releasing this as `0.2.0-next.1` lets agent-dx measure the fix against `next.0`.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code