### PR TITLE
docs: log the fix-404-large result

### DIFF
--- a/docs/agent-dx-log.md
+++ b/docs/agent-dx-log.md
@@ -3,6 +3,30 @@
 How measurements from [honojs/agent-dx](https://github.com/honojs/agent-dx)
 changed Hono CLI. Newest first.
 
+## 2026-09-03: Route count does not matter — locality does (no change)
+
+**Experiment**: `fix-404-large` — the same double-prefix mount bug in a
+27-route shop API. haiku, baseline vs CLI (`0.2.0-next.0`) + skill,
+5 runs each.
+
+**Findings**:
+
+- Both arms 100% success. The CLI arm cost more tokens (+24%) and used
+  the CLI in 0/5 runs — down from 2/5 on the small fixture.
+- The hypothesis "more routes make exploring expensive" was wrong: the
+  404 path `/api/orders` maps straight to `routes/orders.ts`, so one
+  grep lands on the right file. Route count never mattered.
+
+**Changes**: none. The sharpened hypothesis instead: `routes` and
+`--trace` are structurally needed when the bug is **not local** — when
+the file the path points to is correct, and the cause lives elsewhere
+(route shadowing: an earlier wildcard, an early-returning middleware, a
+mount typo).
+
+**Next measurement**: a route-shadowing fixture, in two variants — a 404
+(measures the #108 suggestion) and a wrong 200 (measures discovery
+without it). Then `next.0` vs `next.1` on that ground.
+
 ## 2026-09-02: Agents never discover `--trace` — suggest it on a 404 (#108)
 
 **Experiment**: the `fix-404` task on haiku. Four conditions — nothing /


### PR DESCRIPTION
Record the fix-404-large experiment in the agent-dx log. No CLI change came out of it — the finding is that route count does not matter, locality of the bug does. The next fixture (route shadowing) tests that.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code