### PR TITLE
docs(request): note not to pass credentials in arguments

### DIFF
--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -30,6 +30,7 @@ export const agentContext: CommandAgentContext = {
   ],
   notes: [
     'No server needed. The request goes directly to app.request().',
+    'Do not pass credentials in CLI arguments. Use environment variables for sensitive values.',
     'Pass - as the file to read the app code from stdin. `app` is predefined and exported for you — write only routes. Code with its own `export default` is used as-is.',
     '-d @file reads the body from a file, -d @- reads it from stdin.',
     '--runtime runs the app on bun, deno, or workerd instead of Node.js. bun and deno must be installed. workerd starts the app with the wrangler config of the project, so the local bindings (c.env) are real — it needs wrangler installed and no file argument.',


### PR DESCRIPTION
The security note moved out of the skill (honojs/skills#2 made the skill lean). Its right home is agent-context, which ships with the CLI.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [ ] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code