### PR TITLE
feat(request)!: take the request path as the first argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ hono agent-context
 hono routes
 
 # Send request to Hono app
-hono request
+hono request /
 
 # Measure the performance of your Hono app
 hono benchmark
@@ -55,7 +55,7 @@ Start here:
 Inspect and test:
 
 - `routes [file]` - Show routes of your Hono app
-- `request [file]` - Send request to Hono app using `app.request()`
+- `request <path> [file]` - Send request to Hono app using `app.request()`
 - `benchmark [file]` - Measure the performance of your Hono app
 
 Build:
@@ -111,19 +111,16 @@ hono routes [file] [options]
 Send HTTP requests to your Hono application using the built-in `app.request()` method. This is particularly useful for testing and development.
 
 ```bash
-hono request [file] [path] [options]
+hono request <path> [file] [options]
 ```
 
 **Arguments:**
 
+- `path` - Request path, like the URL in curl
 - `file` - Path to the Hono app file (TypeScript/JSX supported, optional)
-- `path` - curl style: like the URL in curl, a `/`-leading argument
-  is the request path. Same as `-P`. The method stays in `-X`,
-  like curl
 
 **Options:**
 
-- `-P, --path <path>` - Request path (default: "/")
 - `-X, --method <method>` - HTTP method (default: GET)
 - `-d, --data <data>` - Request body data (`@file` reads a file, `@-` reads stdin)
 - `-H, --header <header>` - Custom headers (can be used multiple times)
@@ -140,45 +137,42 @@ hono request [file] [path] [options]
 **Examples:**
 
 ```bash
-# GET request to default app root (uses src/index.ts or src/index.tsx)
-hono request
+# GET request to the app root (the app is found in src/index.ts or src/index.tsx)
+hono request /
 
-# GET request to specific path
-hono request -P /users/123
-
-# The same, curl style
+# GET request to a path, like curl
 hono request /users/123
 
 # POST request with data
-hono request -P /api/users -X POST -d '{"name":"Alice"}'
+hono request /api/users -X POST -d '{"name":"Alice"}'
 
-# Request to specific file
-hono request -P /api src/your-app.ts
+# Request to a specific app file
+hono request /api src/your-app.ts
 
 # Request with custom headers
-hono request -P /api/protected \
+hono request /api/protected \
   -H 'Authorization: Bearer token' \
   -H 'User-Agent: MyApp' \
   src/your-app.ts
 
 # Request with external packages (useful for Node.js native modules)
-hono request -e pg -e dotenv src/your-app.ts
+hono request / src/your-app.ts -e pg -e dotenv
 
 # Read the request body from stdin
-cat payload.json | hono request -P /api/users -X POST -d @-
+cat payload.json | hono request /api/users -X POST -d @-
 
 # Read the app code from stdin: `app` is predefined and exported for you
-echo 'app.get("/hello", (c) => c.json({ ok: true }))' | hono request - -P /hello
+echo 'app.get("/hello", (c) => c.json({ ok: true }))' | hono request /hello -
 
 # Debug an unexpected response: which middleware and handler matched?
-hono request -P /api/users/123 --trace
+hono request /api/users/123 --trace
 
 # Run the app on another runtime (it must be installed)
-hono request -P / --runtime bun
-hono request -P / --runtime deno
+hono request / --runtime bun
+hono request / --runtime deno
 
 # Run the app on workerd with your wrangler config: bindings (c.env) are the local ones
-hono request -P /api --runtime workerd
+hono request /api --runtime workerd
 ```
 
 `workerd` starts the app with the wrangler config of the project, so pass no file argument. It needs [wrangler](https://developers.cloudflare.com/workers/wrangler/) installed in the project. wrangler is not a dependency of Hono CLI.

--- a/README.md
+++ b/README.md
@@ -111,12 +111,15 @@ hono routes [file] [options]
 Send HTTP requests to your Hono application using the built-in `app.request()` method. This is particularly useful for testing and development.
 
 ```bash
-hono request [file] [options]
+hono request [file] [method] [path] [options]
 ```
 
 **Arguments:**
 
 - `file` - Path to the Hono app file (TypeScript/JSX supported, optional)
+- `method`, `path` - curl style: `hono request GET /api/users` works.
+  An upper-case HTTP method sets the method, a `/`-leading argument
+  sets the path. Same as `-X` and `-P`
 
 **Options:**
 
@@ -142,6 +145,9 @@ hono request
 
 # GET request to specific path
 hono request -P /users/123
+
+# The same, curl style
+hono request GET /users/123
 
 # POST request with data
 hono request -P /api/users -X POST -d '{"name":"Alice"}'

--- a/README.md
+++ b/README.md
@@ -111,15 +111,15 @@ hono routes [file] [options]
 Send HTTP requests to your Hono application using the built-in `app.request()` method. This is particularly useful for testing and development.
 
 ```bash
-hono request [file] [method] [path] [options]
+hono request [file] [path] [options]
 ```
 
 **Arguments:**
 
 - `file` - Path to the Hono app file (TypeScript/JSX supported, optional)
-- `method`, `path` - curl style: `hono request GET /api/users` works.
-  An upper-case HTTP method sets the method, a `/`-leading argument
-  sets the path. Same as `-X` and `-P`
+- `path` - curl style: like the URL in curl, a `/`-leading argument
+  is the request path. Same as `-P`. The method stays in `-X`,
+  like curl
 
 **Options:**
 
@@ -147,7 +147,7 @@ hono request
 hono request -P /users/123
 
 # The same, curl style
-hono request GET /users/123
+hono request /users/123
 
 # POST request with data
 hono request -P /api/users -X POST -d '{"name":"Alice"}'

--- a/docs/agent-dx-log.md
+++ b/docs/agent-dx-log.md
@@ -22,8 +22,11 @@ command recording.
 
 **Changes**:
 
-- `request` accepts curl-style positionals: `hono request GET
-  /api/orders` and `hono request /api/orders` now work.
+- `request` accepts the path as an argument, like the URL in curl:
+  `hono request /api/orders` works. A method-like argument
+  (`hono request GET /api/orders`) is an error with the exact fix as
+  a suggestion (`-X GET -P /api/orders`) — curl takes no method
+  argument either, and one corrected retry beats a second syntax.
 - Argument parse errors (unknown option, bad argument) return the JSON
   envelope with an `INVALID_ARGUMENTS` code and a help suggestion,
   like every other error.

--- a/docs/agent-dx-log.md
+++ b/docs/agent-dx-log.md
@@ -22,11 +22,14 @@ command recording.
 
 **Changes**:
 
-- `request` accepts the path as an argument, like the URL in curl:
-  `hono request /api/orders` works. A method-like argument
-  (`hono request GET /api/orders`) is an error with the exact fix as
-  a suggestion (`-X GET -P /api/orders`) — curl takes no method
-  argument either, and one corrected retry beats a second syntax.
+- `request` now takes the request path as its first argument, like
+  the URL in curl: `hono request /api/orders`. The app file moved to
+  the optional second argument, and `-P` is gone — one syntax, and no
+  guessing between a file and a path.
+- A method-like first argument is not interpreted. `hono request GET
+  /api/orders` answers with the exact fix in `suggestions`:
+  `hono request /api/orders -X GET`. One wrong try, one corrected
+  retry — suggestion following is measured at 2/2.
 - Argument parse errors (unknown option, bad argument) return the JSON
   envelope with an `INVALID_ARGUMENTS` code and a help suggestion,
   like every other error.

--- a/docs/agent-dx-log.md
+++ b/docs/agent-dx-log.md
@@ -3,6 +3,31 @@
 How measurements from [honojs/agent-dx](https://github.com/honojs/agent-dx)
 changed Hono CLI. Newest first.
 
+## 2026-09-03: Agents type curl syntax, hit a dead end, and leave
+
+**Experiment**: `fix-404-shadow` — haiku, baseline vs CLI
+(`0.2.0-next.0`) + skill, 5 runs each. The first experiment with full
+command recording.
+
+**Findings**:
+
+- A recorded run shows an agent trying to use `request` three times and
+  failing on syntax every time: `hono request GET /api/orders`, then
+  `hono request "/api/orders"`, then with a guessed `--app` option. It
+  gave up and wrote a throwaway test script instead.
+- The errors it got were commander's plain text (`error: too many
+  arguments`) — outside the JSON envelope, with no suggestion of the
+  correct syntax. The moment of highest intent to use the CLI was a
+  dead end.
+
+**Changes**:
+
+- `request` accepts curl-style positionals: `hono request GET
+  /api/orders` and `hono request /api/orders` now work.
+- Argument parse errors (unknown option, bad argument) return the JSON
+  envelope with an `INVALID_ARGUMENTS` code and a help suggestion,
+  like every other error.
+
 ## 2026-09-03: Route count does not matter — locality does (no change)
 
 **Experiment**: `fix-404-large` — the same double-prefix mount bug in a

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander'
+import { Command, CommanderError } from 'commander'
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -8,6 +8,7 @@ import { optimizeCommand } from './commands/optimize/index.js'
 import { requestCommand } from './commands/request/index.js'
 import { routesCommand } from './commands/routes/index.js'
 import { ssgCommand } from './commands/ssg/index.js'
+import { formatArgumentsError } from './utils/output.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -22,6 +23,8 @@ program
   .description('CLI for Hono')
   .version(packageJson.version, '-v, --version', 'display version number')
   .addHelpText('after', "\nFor coding agents: run 'hono agent-context' and follow it.")
+  .exitOverride()
+  .configureOutput({ writeErr: () => {} })
 
 // Register commands
 agentContextCommand(program)
@@ -31,4 +34,19 @@ benchmarkCommand(program)
 optimizeCommand(program)
 ssgCommand(program)
 
-program.parse()
+try {
+  await program.parseAsync()
+} catch (e) {
+  if (!(e instanceof CommanderError)) {
+    throw e
+  }
+  if (e.exitCode !== 0) {
+    if (e.code === 'commander.help') {
+      // No subcommand given: show the help, not a JSON error
+      program.outputHelp()
+    } else {
+      console.log(formatArgumentsError(e.message))
+    }
+    process.exitCode = 1
+  }
+}

--- a/src/commands/agent-context/document.ts
+++ b/src/commands/agent-context/document.ts
@@ -17,7 +17,10 @@ const contexts: Record<string, CommandAgentContext> = {
 
 const commandDoc = (command: Command, context?: CommandAgentContext): string => {
   const args = command.registeredArguments
-    .map((arg) => (arg.required ? `<${arg.name()}>` : `[${arg.name()}]`))
+    .map((arg) => {
+      const name = arg.variadic ? `${arg.name()}...` : arg.name()
+      return arg.required ? `<${name}>` : `[${name}]`
+    })
     .join(' ')
 
   const optionLines = command.options.map((option) => {

--- a/src/commands/agent-context/index.test.ts
+++ b/src/commands/agent-context/index.test.ts
@@ -46,7 +46,7 @@ describe('agentContextCommand', () => {
   it('should document every command except itself', async () => {
     const output = await getOutput()
     expect(output).toContain('### hono optimize [entry]')
-    expect(output).toContain('### hono request [file]')
+    expect(output).toContain('### hono request [file|method|path...]')
     expect(output).toContain('### hono routes [file]')
     expect(output).not.toContain('### hono agent-context')
   })

--- a/src/commands/agent-context/index.test.ts
+++ b/src/commands/agent-context/index.test.ts
@@ -46,7 +46,7 @@ describe('agentContextCommand', () => {
   it('should document every command except itself', async () => {
     const output = await getOutput()
     expect(output).toContain('### hono optimize [entry]')
-    expect(output).toContain('### hono request [file|method|path...]')
+    expect(output).toContain('### hono request [file|path...]')
     expect(output).toContain('### hono routes [file]')
     expect(output).not.toContain('### hono agent-context')
   })

--- a/src/commands/agent-context/index.test.ts
+++ b/src/commands/agent-context/index.test.ts
@@ -46,7 +46,7 @@ describe('agentContextCommand', () => {
   it('should document every command except itself', async () => {
     const output = await getOutput()
     expect(output).toContain('### hono optimize [entry]')
-    expect(output).toContain('### hono request [file|path...]')
+    expect(output).toContain('### hono request [path] [file]')
     expect(output).toContain('### hono routes [file]')
     expect(output).not.toContain('### hono agent-context')
   })
@@ -54,7 +54,7 @@ describe('agentContextCommand', () => {
   it('should include options from the command definitions', async () => {
     const output = await getOutput()
     expect(output).toContain('`--request-body-api-removal <mode>`')
-    expect(output).toContain('`-P, --path <path>`')
+    expect(output).toContain('`-X, --method <method>`')
     expect(output).toContain('`--verbose`')
   })
 

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -103,6 +103,32 @@ describe('requestCommand', () => {
     })
   })
 
+  it('should accept curl-style method and path positionals', async () => {
+    const mockApp = new Hono()
+    mockApp.post('/data', (c) => c.json({ created: true }))
+    setupBasicMocks('test-app.js', mockApp)
+    mockModules.existsSync.mockImplementation((p) => String(p).endsWith('test-app.js'))
+    await program.parseAsync(['node', 'test', 'request', 'POST', '/data', 'test-app.js'])
+    expect(JSON.parse(consoleLogSpy.mock.calls[0][0])).toEqual({
+      ok: true,
+      data: {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        body: { created: true },
+      },
+    })
+  })
+
+  it('should error when a positional path conflicts with -P', async () => {
+    const mockApp = new Hono()
+    setupBasicMocks('test-app.js', mockApp)
+    mockModules.existsSync.mockReturnValue(false)
+    await program.parseAsync(['node', 'test', 'request', '/a', '-P', '/b'])
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(output.ok).toBe(false)
+    expect(output.error.code).toBe('INVALID_ARGUMENTS')
+  })
+
   it('should output a text body as a string in the envelope', async () => {
     const mockApp = new Hono()
     const text = 'Hello, World!'

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -103,12 +103,12 @@ describe('requestCommand', () => {
     })
   })
 
-  it('should accept curl-style method and path positionals', async () => {
+  it('should accept the request path as a curl-style argument', async () => {
     const mockApp = new Hono()
     mockApp.post('/data', (c) => c.json({ created: true }))
     setupBasicMocks('test-app.js', mockApp)
     mockModules.existsSync.mockImplementation((p) => String(p).endsWith('test-app.js'))
-    await program.parseAsync(['node', 'test', 'request', 'POST', '/data', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '-X', 'POST', '/data', 'test-app.js'])
     expect(JSON.parse(consoleLogSpy.mock.calls[0][0])).toEqual({
       ok: true,
       data: {
@@ -117,6 +117,17 @@ describe('requestCommand', () => {
         body: { created: true },
       },
     })
+  })
+
+  it('should suggest -X for a method-like argument', async () => {
+    const mockApp = new Hono()
+    setupBasicMocks('test-app.js', mockApp)
+    mockModules.existsSync.mockReturnValue(false)
+    await program.parseAsync(['node', 'test', 'request', 'GET', '/data'])
+    const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
+    expect(output.ok).toBe(false)
+    expect(output.error.code).toBe('INVALID_ARGUMENTS')
+    expect(output.error.suggestions).toEqual(['Pass it with -X: hono request -X GET -P /data'])
   })
 
   it('should error when a positional path conflicts with -P', async () => {

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -92,7 +92,7 @@ describe('requestCommand', () => {
     const jsonBody = { message: 'Success' }
     mockApp.get('/data', (c) => c.json(jsonBody))
     setupBasicMocks('test-app.js', mockApp)
-    await program.parseAsync(['node', 'test', 'request', '-P', '/data', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/data', 'test-app.js'])
     expect(JSON.parse(consoleLogSpy.mock.calls[0][0])).toEqual({
       ok: true,
       data: {
@@ -103,23 +103,7 @@ describe('requestCommand', () => {
     })
   })
 
-  it('should accept the request path as a curl-style argument', async () => {
-    const mockApp = new Hono()
-    mockApp.post('/data', (c) => c.json({ created: true }))
-    setupBasicMocks('test-app.js', mockApp)
-    mockModules.existsSync.mockImplementation((p) => String(p).endsWith('test-app.js'))
-    await program.parseAsync(['node', 'test', 'request', '-X', 'POST', '/data', 'test-app.js'])
-    expect(JSON.parse(consoleLogSpy.mock.calls[0][0])).toEqual({
-      ok: true,
-      data: {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-        body: { created: true },
-      },
-    })
-  })
-
-  it('should suggest -X for a method-like argument', async () => {
+  it('should correct curl-style arguments with the exact command', async () => {
     const mockApp = new Hono()
     setupBasicMocks('test-app.js', mockApp)
     mockModules.existsSync.mockReturnValue(false)
@@ -127,17 +111,7 @@ describe('requestCommand', () => {
     const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
     expect(output.ok).toBe(false)
     expect(output.error.code).toBe('INVALID_ARGUMENTS')
-    expect(output.error.suggestions).toEqual(['Pass it with -X: hono request -X GET -P /data'])
-  })
-
-  it('should error when a positional path conflicts with -P', async () => {
-    const mockApp = new Hono()
-    setupBasicMocks('test-app.js', mockApp)
-    mockModules.existsSync.mockReturnValue(false)
-    await program.parseAsync(['node', 'test', 'request', '/a', '-P', '/b'])
-    const output = JSON.parse(consoleLogSpy.mock.calls[0][0])
-    expect(output.ok).toBe(false)
-    expect(output.error.code).toBe('INVALID_ARGUMENTS')
+    expect(output.error.suggestions).toEqual(['hono request /data -X GET'])
   })
 
   it('should output a text body as a string in the envelope', async () => {
@@ -145,7 +119,7 @@ describe('requestCommand', () => {
     const text = 'Hello, World!'
     mockApp.get('/data', (c) => c.text(text))
     setupBasicMocks('test-app.js', mockApp)
-    await program.parseAsync(['node', 'test', 'request', '-P', '/data', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/data', 'test-app.js'])
     expect(JSON.parse(consoleLogSpy.mock.calls[0][0])).toEqual({
       ok: true,
       data: {
@@ -163,7 +137,7 @@ describe('requestCommand', () => {
     const expectedPath = 'test-app.js'
     setupBasicMocks(expectedPath, mockApp)
 
-    await program.parseAsync(['node', 'test', 'request', '-P', '/', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/', 'test-app.js'])
 
     // Verify resolve was called with correct arguments
     expect(mockModules.resolve).toHaveBeenCalledWith(process.cwd(), 'test-app.js')
@@ -191,7 +165,7 @@ describe('requestCommand', () => {
     const expectedPath = 'test-app.js'
     setupBasicMocks(expectedPath, mockApp)
 
-    await program.parseAsync(['node', 'test', 'request', '-w', '-P', '/', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '-w', '/', 'test-app.js'])
 
     // Verify resolve was called with correct arguments
     expect(mockModules.resolve).toHaveBeenCalledWith(process.cwd(), 'test-app.js')
@@ -222,7 +196,7 @@ describe('requestCommand', () => {
     )
     setupBasicMocks('test-app.js', mockApp)
 
-    await program.parseAsync(['node', 'test', 'request', '-P', '/json-charset', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/json-charset', 'test-app.js'])
 
     expect(JSON.parse(consoleLogSpy.mock.calls[0][0])).toEqual({
       ok: true,
@@ -242,7 +216,7 @@ describe('requestCommand', () => {
     mockApp.get('/json-obj', (c) => c.json(jsonBody))
     setupBasicMocks('test-app.js', mockApp)
 
-    await program.parseAsync(['node', 'test', 'request', '-P', '/json-obj', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/json-obj', 'test-app.js'])
 
     expect(JSON.parse(consoleLogSpy.mock.calls[0][0])).toEqual({
       ok: true,
@@ -268,7 +242,6 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
-      '-P',
       '/data',
       '-X',
       'POST',
@@ -307,7 +280,7 @@ describe('requestCommand', () => {
     })
     mockBuildAndImportApp.mockReturnValue(createBuildIterator(mockApp))
 
-    await program.parseAsync(['node', 'test', 'request'])
+    await program.parseAsync(['node', 'test', 'request', '/'])
 
     // Verify resolve was called with correct arguments for default candidates
     expect(mockModules.resolve).toHaveBeenCalledWith(process.cwd(), 'src/index.ts')
@@ -341,7 +314,6 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
-      '-P',
       '/api/test',
       '-H',
       'Authorization: Bearer token123',
@@ -374,7 +346,6 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
-      '-P',
       '/api/multi',
       '-H',
       'Authorization: Bearer token456',
@@ -405,7 +376,7 @@ describe('requestCommand', () => {
     const expectedPath = 'test-app.js'
     setupBasicMocks(expectedPath, mockApp)
 
-    await program.parseAsync(['node', 'test', 'request', '-P', '/api/noheader', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/api/noheader', 'test-app.js'])
 
     // Should not include any custom headers, only default ones
     const output = consoleLogSpy.mock.calls[0][0]
@@ -428,7 +399,6 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
-      '-P',
       '/api/malformed',
       '-H',
       'MalformedHeader', // Missing colon
@@ -453,7 +423,7 @@ describe('requestCommand', () => {
     const htmlContent = '<h1>Hello World</h1>'
     mockApp.get('/html', (c) => c.html(htmlContent))
     setupBasicMocks('test-app.js', mockApp)
-    await program.parseAsync(['node', 'test', 'request', '-P', '/html', '--plain', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/html', '--plain', 'test-app.js'])
     expect(consoleLogSpy).toHaveBeenCalledWith(htmlContent)
   })
 
@@ -462,7 +432,7 @@ describe('requestCommand', () => {
     const xmlContent = '<root><message>Hello</message></root>'
     mockApp.get('/xml', (c) => c.body(xmlContent, 200, { 'Content-Type': 'application/xml' }))
     setupBasicMocks('test-app.js', mockApp)
-    await program.parseAsync(['node', 'test', 'request', '-P', '/xml', '--plain', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/xml', '--plain', 'test-app.js'])
     expect(consoleLogSpy).toHaveBeenCalledWith(xmlContent)
   })
 
@@ -471,15 +441,7 @@ describe('requestCommand', () => {
     const pngData = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 0])
     mockApp.get('/image.png', (c) => c.body(pngData.buffer, 200, { 'Content-Type': 'image/png' }))
     setupBasicMocks('test-app.js', mockApp)
-    await program.parseAsync([
-      'node',
-      'test',
-      'request',
-      '-P',
-      '/image.png',
-      '--plain',
-      'test-app.js',
-    ])
+    await program.parseAsync(['node', 'test', 'request', '/image.png', '--plain', 'test-app.js'])
     expect(consoleWarnSpy).toHaveBeenCalledWith('Binary output can mess up your terminal.')
     expect(consoleLogSpy).not.toHaveBeenCalled()
   })
@@ -489,7 +451,7 @@ describe('requestCommand', () => {
     const pngData = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 0])
     mockApp.get('/image.png', (c) => c.body(pngData.buffer, 200, { 'Content-Type': 'image/png' }))
     setupBasicMocks('test-app.js', mockApp)
-    await program.parseAsync(['node', 'test', 'request', '-P', '/image.png', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/image.png', 'test-app.js'])
     expect(JSON.parse(consoleLogSpy.mock.calls[0][0])).toEqual({
       ok: true,
       data: {
@@ -509,15 +471,7 @@ describe('requestCommand', () => {
       c.body(pdfData.buffer, 200, { 'Content-Type': 'application/pdf' })
     )
     setupBasicMocks('test-app.js', mockApp)
-    await program.parseAsync([
-      'node',
-      'test',
-      'request',
-      '-P',
-      '/document.pdf',
-      '--plain',
-      'test-app.js',
-    ])
+    await program.parseAsync(['node', 'test', 'request', '/document.pdf', '--plain', 'test-app.js'])
     expect(consoleWarnSpy).toHaveBeenCalledWith('Binary output can mess up your terminal.')
     expect(consoleLogSpy).not.toHaveBeenCalled()
   })
@@ -547,7 +501,6 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
-      '-P',
       '/resource',
       '-w',
       '--plain',
@@ -572,7 +525,6 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
-      '-P',
       '/save-json',
       '-o',
       outputPath,
@@ -602,7 +554,6 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
-      '-P',
       '/save-binary',
       '-o',
       outputPath,
@@ -628,7 +579,7 @@ describe('requestCommand', () => {
     )
     mockGetFilenameFromPath.mockReturnValue('index.html')
 
-    await program.parseAsync(['node', 'test', 'request', '-P', '/index.html', '-O', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/index.html', '-O', 'test-app.js'])
 
     expect(mockGetFilenameFromPath).toHaveBeenCalledWith('/index.html', 'text/html; charset=UTF-8')
     const saved = mockSaveFile.mock.calls[0]
@@ -650,7 +601,7 @@ describe('requestCommand', () => {
     )
     mockGetFilenameFromPath.mockReturnValue('image.png')
 
-    await program.parseAsync(['node', 'test', 'request', '-P', '/image.png', '-O', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/image.png', '-O', 'test-app.js'])
 
     expect(mockGetFilenameFromPath).toHaveBeenCalledWith('/image.png', 'image/png')
     const saved = mockSaveFile.mock.calls[0]
@@ -672,7 +623,7 @@ describe('requestCommand', () => {
     )
     mockGetFilenameFromPath.mockReturnValue('index')
 
-    await program.parseAsync(['node', 'test', 'request', '-P', '/', '-O', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/', '-O', 'test-app.js'])
 
     expect(mockGetFilenameFromPath).toHaveBeenCalledWith('/', 'text/html; charset=UTF-8')
     const saved = mockSaveFile.mock.calls[0]
@@ -699,7 +650,6 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
-      '-P',
       '/text.txt',
       '-o',
       outputPath,
@@ -728,7 +678,6 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
-      '-P',
       '/filtered-data',
       '-o',
       outputPath,
@@ -747,16 +696,7 @@ describe('requestCommand', () => {
     mockApp.get('/text', (c) => c.text(textBody, 200, { 'X-Custom-Header': 'IncludeValue' }))
     setupBasicMocks('test-app.js', mockApp)
 
-    await program.parseAsync([
-      'node',
-      'test',
-      'request',
-      '-P',
-      '/text',
-      '--plain',
-      '-i',
-      'test-app.js',
-    ])
+    await program.parseAsync(['node', 'test', 'request', '/text', '--plain', '-i', 'test-app.js'])
 
     const expectedOutput = [
       '200',
@@ -775,16 +715,7 @@ describe('requestCommand', () => {
     mockApp.get('/text', (c) => c.text(textBody, 200, { 'X-Custom-Header': 'HeadValue' }))
     setupBasicMocks('test-app.js', mockApp)
 
-    await program.parseAsync([
-      'node',
-      'test',
-      'request',
-      '-P',
-      '/text',
-      '--plain',
-      '-I',
-      'test-app.js',
-    ])
+    await program.parseAsync(['node', 'test', 'request', '/text', '--plain', '-I', 'test-app.js'])
 
     const expectedOutput = [
       '200',
@@ -806,7 +737,6 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
-      '-P',
       '/text',
       '--plain',
       '-i',
@@ -834,7 +764,6 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
-      '-P',
       '/json-data',
       '--plain',
       '-i',
@@ -858,7 +787,7 @@ describe('requestCommand', () => {
     const expectedPath = 'test-app.js'
     setupBasicMocks(expectedPath, mockApp)
 
-    await program.parseAsync(['node', 'test', 'request', '-e', 'pg', 'test-app.js'])
+    await program.parseAsync(['node', 'test', 'request', '/', '-e', 'pg', 'test-app.js'])
 
     expect(mockBuildAndImportApp).toHaveBeenCalledWith(expectedPath, {
       external: ['@hono/node-server', 'pg'],
@@ -878,6 +807,7 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
+      '/',
       '-e',
       'pg',
       '-e',
@@ -905,6 +835,7 @@ describe('requestCommand', () => {
       'node',
       'test',
       'request',
+      '/',
       '--external',
       'pg',
       '--external',
@@ -953,15 +884,7 @@ describe('requestCommand', () => {
         mockApp.get('/test', (c) => c.body(jsonString, 200, { 'Content-Type': contentType }))
         setupBasicMocks('test-app.js', mockApp)
 
-        await program.parseAsync([
-          'node',
-          'test',
-          'request',
-          '-P',
-          '/test',
-          '--plain',
-          'test-app.js',
-        ])
+        await program.parseAsync(['node', 'test', 'request', '/test', '--plain', 'test-app.js'])
 
         expect(consoleLogSpy).toHaveBeenCalledWith(formattedJsonString)
       })
@@ -973,15 +896,7 @@ describe('requestCommand', () => {
         mockApp.get('/test', (c) => c.body(jsonString, 200, { 'Content-Type': contentType }))
         setupBasicMocks('test-app.js', mockApp)
 
-        await program.parseAsync([
-          'node',
-          'test',
-          'request',
-          '-P',
-          '/test',
-          '--plain',
-          'test-app.js',
-        ])
+        await program.parseAsync(['node', 'test', 'request', '/test', '--plain', 'test-app.js'])
 
         expect(consoleLogSpy).toHaveBeenCalledWith(jsonString)
       })
@@ -992,7 +907,7 @@ describe('requestCommand', () => {
     mockModules.existsSync.mockReturnValue(false)
     mockModules.resolve.mockImplementation((cwd: string, path: string) => `${cwd}/${path}`)
 
-    await program.parseAsync(['node', 'test', 'request', 'missing.ts'])
+    await program.parseAsync(['node', 'test', 'request', '/', 'missing.ts'])
 
     const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
     expect(parsed.ok).toBe(false)
@@ -1013,7 +928,6 @@ describe('requestCommand', () => {
         'node',
         'test',
         'request',
-        '-P',
         '/echo',
         '-X',
         'POST',
@@ -1037,7 +951,6 @@ describe('requestCommand', () => {
         'node',
         'test',
         'request',
-        '-P',
         '/echo',
         '-X',
         'POST',
@@ -1057,7 +970,7 @@ describe('requestCommand', () => {
       mockModules.readFileSync.mockReturnValue('export default app')
       mockBuildAndImportApp.mockReturnValue(createBuildIterator(mockApp))
 
-      await program.parseAsync(['node', 'test', 'request', '-', '-P', '/'])
+      await program.parseAsync(['node', 'test', 'request', '/', '-'])
 
       expect(mockModules.readFileSync).toHaveBeenCalledWith(0, 'utf-8')
       expect(mockBuildAndImportApp).toHaveBeenCalledWith(
@@ -1074,7 +987,7 @@ describe('requestCommand', () => {
       mockModules.readFileSync.mockReturnValue('app.get("/", (c) => c.text("wrapped"))')
       mockBuildAndImportApp.mockReturnValue(createBuildIterator(mockApp))
 
-      await program.parseAsync(['node', 'test', 'request', '-', '-P', '/'])
+      await program.parseAsync(['node', 'test', 'request', '/', '-'])
 
       expect(mockBuildAndImportApp).toHaveBeenCalledWith(
         {
@@ -1091,7 +1004,7 @@ describe('requestCommand', () => {
     })
 
     it('should reject - together with -d @-', async () => {
-      await program.parseAsync(['node', 'test', 'request', '-', '-d', '@-'])
+      await program.parseAsync(['node', 'test', 'request', '/', '-', '-d', '@-'])
 
       const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(parsed.ok).toBe(false)
@@ -1101,7 +1014,7 @@ describe('requestCommand', () => {
     })
 
     it('should reject - together with --watch', async () => {
-      await program.parseAsync(['node', 'test', 'request', '-', '-w'])
+      await program.parseAsync(['node', 'test', 'request', '/', '-', '-w'])
 
       const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(parsed.ok).toBe(false)
@@ -1126,7 +1039,6 @@ describe('requestCommand', () => {
         'node',
         'test',
         'request',
-        '-P',
         '/api/users/123',
         '--trace',
         'test-app.js',
@@ -1147,7 +1059,15 @@ describe('requestCommand', () => {
     })
 
     it('should reject --trace with --plain', async () => {
-      await program.parseAsync(['node', 'test', 'request', '--trace', '--plain', 'test-app.js'])
+      await program.parseAsync([
+        'node',
+        'test',
+        'request',
+        '/',
+        '--trace',
+        '--plain',
+        'test-app.js',
+      ])
 
       const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(parsed.ok).toBe(false)
@@ -1177,7 +1097,6 @@ describe('requestCommand', () => {
         'node',
         'test',
         'request',
-        '-P',
         '/api',
         '-H',
         'X-Key: abc',
@@ -1204,7 +1123,7 @@ describe('requestCommand', () => {
     })
 
     it('should reject an unknown runtime', async () => {
-      await program.parseAsync(['node', 'test', 'request', '--runtime', 'php', 'test-app.js'])
+      await program.parseAsync(['node', 'test', 'request', '/', '--runtime', 'php', 'test-app.js'])
 
       const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(parsed.ok).toBe(false)
@@ -1226,7 +1145,7 @@ describe('requestCommand', () => {
         }),
       })
 
-      await program.parseAsync(['node', 'test', 'request', '-P', '/api', '--runtime', 'workerd'])
+      await program.parseAsync(['node', 'test', 'request', '/api', '--runtime', 'workerd'])
 
       expect(runOnWorkerd).toHaveBeenCalledWith({ path: '/api', method: 'GET', headers: {} })
       const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
@@ -1242,7 +1161,15 @@ describe('requestCommand', () => {
     })
 
     it('should reject a file argument with workerd', async () => {
-      await program.parseAsync(['node', 'test', 'request', '--runtime', 'workerd', 'src/index.ts'])
+      await program.parseAsync([
+        'node',
+        'test',
+        'request',
+        '/',
+        'src/index.ts',
+        '--runtime',
+        'workerd',
+      ])
 
       const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(parsed.ok).toBe(false)
@@ -1251,10 +1178,19 @@ describe('requestCommand', () => {
     })
 
     it('should reject --runtime bun with --watch or --trace', async () => {
-      await program.parseAsync(['node', 'test', 'request', '--runtime', 'bun', '-w', 'a.ts'])
+      await program.parseAsync(['node', 'test', 'request', '/', 'a.ts', '--runtime', 'bun', '-w'])
       expect(JSON.parse(consoleLogSpy.mock.calls[0][0]).error.code).toBe('INVALID_OPTION')
 
-      await program.parseAsync(['node', 'test', 'request', '--runtime', 'deno', '--trace', 'a.ts'])
+      await program.parseAsync([
+        'node',
+        'test',
+        'request',
+        '/',
+        'a.ts',
+        '--runtime',
+        'deno',
+        '--trace',
+      ])
       expect(JSON.parse(consoleLogSpy.mock.calls[1][0]).error.code).toBe('INVALID_OPTION')
       process.exitCode = undefined
     })
@@ -1266,12 +1202,12 @@ describe('requestCommand', () => {
       mockApp.get('/exists', (c) => c.text('ok'))
       setupBasicMocks('test-app.js', mockApp)
 
-      await program.parseAsync(['node', 'test', 'request', '-P', '/missing', 'test-app.js'])
+      await program.parseAsync(['node', 'test', 'request', '/missing', 'test-app.js'])
 
       const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
       expect(parsed.data.status).toBe(404)
       expect(parsed.data.suggestions).toEqual([
-        'See which routes matched: hono request -P /missing --trace',
+        'See which routes matched: hono request /missing --trace',
       ])
     })
 
@@ -1280,19 +1216,11 @@ describe('requestCommand', () => {
       mockApp.get('/exists', (c) => c.text('ok'))
       setupBasicMocks('test-app.js', mockApp)
 
-      await program.parseAsync(['node', 'test', 'request', '-P', '/exists', 'test-app.js'])
+      await program.parseAsync(['node', 'test', 'request', '/exists', 'test-app.js'])
       expect(JSON.parse(consoleLogSpy.mock.calls[0][0]).data.suggestions).toBeUndefined()
 
       setupBasicMocks('test-app.js', mockApp)
-      await program.parseAsync([
-        'node',
-        'test',
-        'request',
-        '-P',
-        '/missing',
-        '--trace',
-        'test-app.js',
-      ])
+      await program.parseAsync(['node', 'test', 'request', '/missing', '--trace', 'test-app.js'])
       expect(JSON.parse(consoleLogSpy.mock.calls[1][0]).data.suggestions).toBeUndefined()
     })
   })

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -4,6 +4,7 @@ import type { CommandAgentContext } from '../../utils/agent-context.js'
 import { getFilenameFromPath, saveFile } from '../../utils/file.js'
 import { getBuildIterator, resolveData, resolveEntry } from '../../utils/load-app.js'
 import { CliError, handleErrors, printResult } from '../../utils/output.js'
+import { classifyPositionals } from './positionals.js'
 import type { Runtime } from './runtime.js'
 import { RUNTIMES, runInRuntime } from './runtime.js'
 import { withTracer } from './trace.js'
@@ -21,6 +22,7 @@ export const agentContext: CommandAgentContext = {
   ],
   examples: [
     'hono request -P /api/users',
+    'hono request GET /api/users',
     `hono request -P /api/users -X POST -d '{"name":"Alice"}'`,
     'cat payload.json | hono request -P /api/users -X POST -d @-',
     'hono request -P /api/users/123 --trace',
@@ -58,7 +60,7 @@ export function requestCommand(program: Command) {
   program
     .command('request')
     .description('Send request to Hono app using app.request()')
-    .argument('[file]', 'Path to the Hono app file')
+    .argument('[file|method|path...]', 'App file, and optionally a method and a path (curl style)')
     .option('-P, --path <path>', 'Request path', '/')
     .option('-X, --method <method>', 'HTTP method', 'GET')
     .option('-d, --data <data>', 'Request body data (@file reads a file, @- reads stdin)')
@@ -91,7 +93,30 @@ export function requestCommand(program: Command) {
       [] as string[]
     )
     .action(
-      handleErrors(async (file: string | undefined, options: RequestOptions) => {
+      handleErrors(async (args: string[], options: RequestOptions) => {
+        const positionals = classifyPositionals(args)
+        if (
+          positionals.method &&
+          options.method !== 'GET' &&
+          positionals.method !== options.method
+        ) {
+          throw new CliError('INVALID_ARGUMENTS', 'Two methods given', {
+            suggestions: ['Use one: hono request -X POST -P /api/orders'],
+          })
+        }
+        if (positionals.path && options.path !== '/' && positionals.path !== options.path) {
+          throw new CliError('INVALID_ARGUMENTS', 'Two paths given', {
+            suggestions: ['Use one: hono request -P /api/orders'],
+          })
+        }
+        const file = positionals.file
+        if (positionals.method) {
+          options.method = positionals.method
+        }
+        if (positionals.path) {
+          options.path = positionals.path
+        }
+
         const doSaveFile = options.output || options.remoteName
         const path = options.path || '/'
         const watch = options.watch

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -22,7 +22,7 @@ export const agentContext: CommandAgentContext = {
   ],
   examples: [
     'hono request -P /api/users',
-    'hono request GET /api/users',
+    'hono request /api/users/123',
     `hono request -P /api/users -X POST -d '{"name":"Alice"}'`,
     'cat payload.json | hono request -P /api/users -X POST -d @-',
     'hono request -P /api/users/123 --trace',
@@ -60,7 +60,7 @@ export function requestCommand(program: Command) {
   program
     .command('request')
     .description('Send request to Hono app using app.request()')
-    .argument('[file|method|path...]', 'App file, and optionally a method and a path (curl style)')
+    .argument('[file|path...]', 'App file, and the request path (curl style)')
     .option('-P, --path <path>', 'Request path', '/')
     .option('-X, --method <method>', 'HTTP method', 'GET')
     .option('-d, --data <data>', 'Request body data (@file reads a file, @- reads stdin)')
@@ -95,24 +95,12 @@ export function requestCommand(program: Command) {
     .action(
       handleErrors(async (args: string[], options: RequestOptions) => {
         const positionals = classifyPositionals(args)
-        if (
-          positionals.method &&
-          options.method !== 'GET' &&
-          positionals.method !== options.method
-        ) {
-          throw new CliError('INVALID_ARGUMENTS', 'Two methods given', {
-            suggestions: ['Use one: hono request -X POST -P /api/orders'],
-          })
-        }
         if (positionals.path && options.path !== '/' && positionals.path !== options.path) {
           throw new CliError('INVALID_ARGUMENTS', 'Two paths given', {
             suggestions: ['Use one: hono request -P /api/orders'],
           })
         }
         const file = positionals.file
-        if (positionals.method) {
-          options.method = positionals.method
-        }
         if (positionals.path) {
           options.path = positionals.path
         }

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -4,7 +4,7 @@ import type { CommandAgentContext } from '../../utils/agent-context.js'
 import { getFilenameFromPath, saveFile } from '../../utils/file.js'
 import { getBuildIterator, resolveData, resolveEntry } from '../../utils/load-app.js'
 import { CliError, handleErrors, printResult } from '../../utils/output.js'
-import { classifyPositionals } from './positionals.js'
+import { resolvePositionals } from './positionals.js'
 import type { Runtime } from './runtime.js'
 import { RUNTIMES, runInRuntime } from './runtime.js'
 import { withTracer } from './trace.js'
@@ -21,14 +21,13 @@ export const agentContext: CommandAgentContext = {
     'WRANGLER_CONFIG_NOT_FOUND',
   ],
   examples: [
-    'hono request -P /api/users',
-    'hono request /api/users/123',
-    `hono request -P /api/users -X POST -d '{"name":"Alice"}'`,
-    'cat payload.json | hono request -P /api/users -X POST -d @-',
-    'hono request -P /api/users/123 --trace',
-    'hono request -P / --runtime bun',
-    'hono request -P /api --runtime workerd',
-    `echo 'app.get("/hello", (c) => c.json({ ok: true }))' | hono request - -P /hello`,
+    'hono request /api/users',
+    `hono request /api/users -X POST -d '{"name":"Alice"}'`,
+    'cat payload.json | hono request /api/users -X POST -d @-',
+    'hono request /api/users/123 --trace',
+    'hono request / --runtime bun',
+    'hono request /api --runtime workerd',
+    `echo 'app.get("/hello", (c) => c.json({ ok: true }))' | hono request /hello -`,
   ],
   notes: [
     'No server needed. The request goes directly to app.request().',
@@ -44,7 +43,6 @@ interface RequestOptions {
   method?: string
   data?: string
   header?: string[]
-  path?: string
   watch: boolean
   plain: boolean
   trace: boolean
@@ -60,8 +58,8 @@ export function requestCommand(program: Command) {
   program
     .command('request')
     .description('Send request to Hono app using app.request()')
-    .argument('[file|path...]', 'App file, and the request path (curl style)')
-    .option('-P, --path <path>', 'Request path', '/')
+    .argument('[path]', 'Request path, like the URL in curl')
+    .argument('[file]', 'Path to the Hono app file')
     .option('-X, --method <method>', 'HTTP method', 'GET')
     .option('-d, --data <data>', 'Request body data (@file reads a file, @- reads stdin)')
     .option('-w, --watch', 'Watch for changes and resend request', false)
@@ -93,95 +91,101 @@ export function requestCommand(program: Command) {
       [] as string[]
     )
     .action(
-      handleErrors(async (args: string[], options: RequestOptions) => {
-        const positionals = classifyPositionals(args)
-        if (positionals.path && options.path !== '/' && positionals.path !== options.path) {
-          throw new CliError('INVALID_ARGUMENTS', 'Two paths given', {
-            suggestions: ['Use one: hono request -P /api/orders'],
-          })
-        }
-        const file = positionals.file
-        if (positionals.path) {
-          options.path = positionals.path
-        }
+      handleErrors(
+        async (
+          pathArg: string | undefined,
+          fileArg: string | undefined,
+          options: RequestOptions
+        ) => {
+          const { path = '/', file } = resolvePositionals(pathArg, fileArg, false)
 
-        const doSaveFile = options.output || options.remoteName
-        const path = options.path || '/'
-        const watch = options.watch
-        const external = options.external || []
-        if (!RUNTIMES.includes(options.runtime as Runtime)) {
-          throw new CliError('INVALID_OPTION', `Unknown runtime: ${options.runtime}`, {
-            suggestions: ['Use one of: node, bun, deno, workerd'],
-          })
-        }
-        const runtime = options.runtime as Runtime
-        if (runtime !== 'node' && (options.watch || options.trace)) {
-          throw new CliError(
-            'INVALID_OPTION',
-            `Cannot use --watch or --trace with --runtime ${runtime}`,
-            {
-              suggestions: ['Drop --watch and --trace, or use --runtime node'],
-            }
-          )
-        }
-        if (options.trace && options.plain) {
-          throw new CliError('INVALID_OPTION', 'Cannot use --trace with --plain', {
-            suggestions: ['Drop --plain. The trace is part of the JSON output'],
-          })
-        }
-        if (file === '-' && options.data === '@-') {
-          throw new CliError('INVALID_OPTION', 'Cannot read both the app and the body from stdin', {
-            suggestions: ['Pass the app as a file, or the body with -d @file'],
-          })
-        }
-        options.data = resolveData(options.data)
-
-        if (runtime === 'workerd') {
-          if (file !== undefined) {
-            throw new CliError('INVALID_OPTION', 'workerd runs the app from your wrangler config', {
-              suggestions: ['Drop the file argument. The entry is `main` in the wrangler config'],
+          const doSaveFile = options.output || options.remoteName
+          const watch = options.watch
+          const external = options.external || []
+          if (!RUNTIMES.includes(options.runtime as Runtime)) {
+            throw new CliError('INVALID_OPTION', `Unknown runtime: ${options.runtime}`, {
+              suggestions: ['Use one of: node, bun, deno, workerd'],
             })
           }
-          const result = await runOnWorkerd({
-            path,
-            method: options.method || 'GET',
-            headers: parseHeaders(options.header),
-            ...(options.data === undefined ? {} : { body: options.data }),
-          })
-          await printResponse(result, path, options, doSaveFile, { runtime })
-          return
-        }
+          const runtime = options.runtime as Runtime
+          if (runtime !== 'node' && (options.watch || options.trace)) {
+            throw new CliError(
+              'INVALID_OPTION',
+              `Cannot use --watch or --trace with --runtime ${runtime}`,
+              {
+                suggestions: ['Drop --watch and --trace, or use --runtime node'],
+              }
+            )
+          }
+          if (options.trace && options.plain) {
+            throw new CliError('INVALID_OPTION', 'Cannot use --trace with --plain', {
+              suggestions: ['Drop --plain. The trace is part of the JSON output'],
+            })
+          }
+          if (file === '-' && options.data === '@-') {
+            throw new CliError(
+              'INVALID_OPTION',
+              'Cannot read both the app and the body from stdin',
+              {
+                suggestions: ['Pass the app as a file, or the body with -d @file'],
+              }
+            )
+          }
+          options.data = resolveData(options.data)
 
-        if (runtime !== 'node') {
-          const runnerResponse = await runInRuntime(runtime, resolveEntry(file), external, {
-            path,
-            method: options.method || 'GET',
-            headers: parseHeaders(options.header),
-            ...(options.data === undefined ? {} : { body: options.data }),
-          })
-          const bytes = Buffer.from(runnerResponse.bodyBase64, 'base64')
-          const result = {
-            status: runnerResponse.status,
-            headers: runnerResponse.headers,
-            body: new TextDecoder().decode(bytes),
-            response: new Response(bytes, {
+          if (runtime === 'workerd') {
+            if (file !== undefined) {
+              throw new CliError(
+                'INVALID_OPTION',
+                'workerd runs the app from your wrangler config',
+                {
+                  suggestions: [
+                    'Drop the file argument. The entry is `main` in the wrangler config',
+                  ],
+                }
+              )
+            }
+            const result = await runOnWorkerd({
+              path,
+              method: options.method || 'GET',
+              headers: parseHeaders(options.header),
+              ...(options.data === undefined ? {} : { body: options.data }),
+            })
+            await printResponse(result, path, options, doSaveFile, { runtime })
+            return
+          }
+
+          if (runtime !== 'node') {
+            const runnerResponse = await runInRuntime(runtime, resolveEntry(file), external, {
+              path,
+              method: options.method || 'GET',
+              headers: parseHeaders(options.header),
+              ...(options.data === undefined ? {} : { body: options.data }),
+            })
+            const bytes = Buffer.from(runnerResponse.bodyBase64, 'base64')
+            const result = {
               status: runnerResponse.status,
               headers: runnerResponse.headers,
-            }),
+              body: new TextDecoder().decode(bytes),
+              response: new Response(bytes, {
+                status: runnerResponse.status,
+                headers: runnerResponse.headers,
+              }),
+            }
+            await printResponse(result, path, options, doSaveFile, { runtime })
+            return
           }
-          await printResponse(result, path, options, doSaveFile, { runtime })
-          return
-        }
 
-        const buildIterator = getBuildIterator(file, watch, external)
-        for await (const app of buildIterator) {
-          const traced = options.trace ? withTracer(app) : undefined
-          const result = await executeRequest(traced?.app ?? app, path, options)
-          await printResponse(result, path, options, doSaveFile, {
-            ...(traced ? { matchedRoutes: traced.getTrace() } : {}),
-          })
+          const buildIterator = getBuildIterator(file, watch, external)
+          for await (const app of buildIterator) {
+            const traced = options.trace ? withTracer(app) : undefined
+            const result = await executeRequest(traced?.app ?? app, path, options)
+            await printResponse(result, path, options, doSaveFile, {
+              ...(traced ? { matchedRoutes: traced.getTrace() } : {}),
+            })
+          }
         }
-      })
+      )
     )
 }
 
@@ -217,7 +221,7 @@ const printResponse = async (
     ...(isBinaryData ? { binary: true } : {}),
     ...(savedTo ? { savedTo } : {}),
     ...(suggestTrace
-      ? { suggestions: [`See which routes matched: hono request -P ${path} --trace`] }
+      ? { suggestions: [`See which routes matched: hono request ${path} --trace`] }
       : {}),
     ...extra,
   })

--- a/src/commands/request/positionals.test.ts
+++ b/src/commands/request/positionals.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CliError } from '../../utils/output.js'
+import { classifyPositionals } from './positionals.js'
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+}))
+
+const getExistsSync = async () => vi.mocked((await import('node:fs')).existsSync)
+
+describe('classifyPositionals', () => {
+  let existsSync: Awaited<ReturnType<typeof getExistsSync>>
+
+  beforeEach(async () => {
+    existsSync = await getExistsSync()
+    existsSync.mockReturnValue(false)
+  })
+
+  it('classifies curl-style method and path', () => {
+    expect(classifyPositionals(['GET', '/api/orders'])).toEqual({
+      method: 'GET',
+      path: '/api/orders',
+    })
+  })
+
+  it('classifies a bare path', () => {
+    expect(classifyPositionals(['/api/orders'])).toEqual({ path: '/api/orders' })
+  })
+
+  it('keeps an existing file as the app file', () => {
+    existsSync.mockReturnValue(true)
+    expect(classifyPositionals(['src/app.ts'])).toEqual({ file: 'src/app.ts' })
+  })
+
+  it('an existing file wins over a method name', () => {
+    existsSync.mockReturnValue(true)
+    expect(classifyPositionals(['GET'])).toEqual({ file: 'GET' })
+  })
+
+  it('keeps - as the stdin file', () => {
+    expect(classifyPositionals(['-'])).toEqual({ file: '-' })
+  })
+
+  it('classifies file, method, and path together', () => {
+    existsSync.mockImplementation((p) => String(p).endsWith('app.ts'))
+    expect(classifyPositionals(['src/app.ts', 'POST', '/api/orders'])).toEqual({
+      file: 'src/app.ts',
+      method: 'POST',
+      path: '/api/orders',
+    })
+  })
+
+  it('treats a missing non-path argument as the app file', () => {
+    expect(classifyPositionals(['missing.ts'])).toEqual({ file: 'missing.ts' })
+  })
+
+  it('throws INVALID_ARGUMENTS on two paths', () => {
+    expect(() => classifyPositionals(['/a', '/b'])).toThrowError(CliError)
+    try {
+      classifyPositionals(['/a', '/b'])
+    } catch (e) {
+      expect(e).toBeInstanceOf(CliError)
+      if (e instanceof CliError) {
+        expect(e.code).toBe('INVALID_ARGUMENTS')
+      }
+    }
+  })
+})

--- a/src/commands/request/positionals.test.ts
+++ b/src/commands/request/positionals.test.ts
@@ -1,78 +1,68 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { CliError } from '../../utils/output.js'
-import { classifyPositionals } from './positionals.js'
+import { resolvePositionals } from './positionals.js'
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
-}))
-
-const getExistsSync = async () => vi.mocked((await import('node:fs')).existsSync)
-
-const expectCliError = (fn: () => unknown, code: string): CliError => {
+const expectSuggestions = (fn: () => unknown): string[] => {
   try {
     fn()
   } catch (e) {
     expect(e).toBeInstanceOf(CliError)
     if (e instanceof CliError) {
-      expect(e.code).toBe(code)
-      return e
+      expect(e.code).toBe('INVALID_ARGUMENTS')
+      return e.suggestions ?? []
     }
   }
   expect.unreachable()
 }
 
-describe('classifyPositionals', () => {
-  let existsSync: Awaited<ReturnType<typeof getExistsSync>>
-
-  beforeEach(async () => {
-    existsSync = await getExistsSync()
-    existsSync.mockReturnValue(false)
-  })
-
-  it('classifies a /-leading argument as the request path, like the URL in curl', () => {
-    expect(classifyPositionals(['/api/orders'])).toEqual({ path: '/api/orders' })
-  })
-
-  it('keeps an existing file as the app file', () => {
-    existsSync.mockReturnValue(true)
-    expect(classifyPositionals(['src/app.ts'])).toEqual({ file: 'src/app.ts' })
-  })
-
-  it('classifies file and path together', () => {
-    existsSync.mockImplementation((p) => String(p).endsWith('app.ts'))
-    expect(classifyPositionals(['src/app.ts', '/api/orders'])).toEqual({
+describe('resolvePositionals', () => {
+  it('takes the path first and the file second', () => {
+    expect(resolvePositionals('/api/users', 'src/app.ts', false)).toEqual({
+      path: '/api/users',
       file: 'src/app.ts',
-      path: '/api/orders',
     })
   })
 
-  it('keeps - as the stdin file', () => {
-    expect(classifyPositionals(['-'])).toEqual({ file: '-' })
+  it('takes the path alone', () => {
+    expect(resolvePositionals('/', undefined, false)).toEqual({ path: '/', file: undefined })
   })
 
-  it('treats a missing non-path argument as the app file', () => {
-    expect(classifyPositionals(['missing.ts'])).toEqual({ file: 'missing.ts' })
+  it('takes - as the stdin app file', () => {
+    expect(resolvePositionals('/hello', '-', false)).toEqual({ path: '/hello', file: '-' })
   })
 
-  it('suggests -X for a method-like argument, with the given path', () => {
-    const error = expectCliError(
-      () => classifyPositionals(['GET', '/api/orders']),
-      'INVALID_ARGUMENTS'
-    )
-    expect(error.suggestions).toEqual(['Pass it with -X: hono request -X GET -P /api/orders'])
+  it('requires the path', () => {
+    expect(expectSuggestions(() => resolvePositionals(undefined, undefined, false))).toEqual([
+      'Request the root: hono request /',
+    ])
   })
 
-  it('suggests -X for a method-like argument without a path', () => {
-    const error = expectCliError(() => classifyPositionals(['POST']), 'INVALID_ARGUMENTS')
-    expect(error.suggestions).toEqual(['Pass it with -X: hono request -X POST -P <path>'])
+  it('corrects a curl-style method argument with the exact command', () => {
+    expect(expectSuggestions(() => resolvePositionals('GET', '/api/orders', false))).toEqual([
+      'hono request /api/orders -X GET',
+    ])
   })
 
-  it('an existing file named like a method stays the app file', () => {
-    existsSync.mockReturnValue(true)
-    expect(classifyPositionals(['GET'])).toEqual({ file: 'GET' })
+  it('corrects a method argument without a path', () => {
+    expect(expectSuggestions(() => resolvePositionals('POST', undefined, false))).toEqual([
+      'hono request <path> -X POST',
+    ])
   })
 
-  it('throws INVALID_ARGUMENTS on two paths', () => {
-    expectCliError(() => classifyPositionals(['/a', '/b']), 'INVALID_ARGUMENTS')
+  it('corrects a file-first call with both readings', () => {
+    expect(expectSuggestions(() => resolvePositionals('src/app.ts', undefined, false))).toEqual([
+      'If src/app.ts is the app file: hono request / src/app.ts',
+      'If it is the path: hono request /src/app.ts',
+    ])
+  })
+
+  it('takes the single batch argument as the app file', () => {
+    expect(resolvePositionals('src/app.ts', undefined, true)).toEqual({ file: 'src/app.ts' })
+  })
+
+  it('rejects a path argument with --batch', () => {
+    expect(expectSuggestions(() => resolvePositionals('/api/users', undefined, true))).toEqual([
+      'Put the path in the batch lines',
+    ])
   })
 })

--- a/src/commands/request/positionals.test.ts
+++ b/src/commands/request/positionals.test.ts
@@ -8,6 +8,19 @@ vi.mock('node:fs', () => ({
 
 const getExistsSync = async () => vi.mocked((await import('node:fs')).existsSync)
 
+const expectCliError = (fn: () => unknown, code: string): CliError => {
+  try {
+    fn()
+  } catch (e) {
+    expect(e).toBeInstanceOf(CliError)
+    if (e instanceof CliError) {
+      expect(e.code).toBe(code)
+      return e
+    }
+  }
+  expect.unreachable()
+}
+
 describe('classifyPositionals', () => {
   let existsSync: Awaited<ReturnType<typeof getExistsSync>>
 
@@ -16,14 +29,7 @@ describe('classifyPositionals', () => {
     existsSync.mockReturnValue(false)
   })
 
-  it('classifies curl-style method and path', () => {
-    expect(classifyPositionals(['GET', '/api/orders'])).toEqual({
-      method: 'GET',
-      path: '/api/orders',
-    })
-  })
-
-  it('classifies a bare path', () => {
+  it('classifies a /-leading argument as the request path, like the URL in curl', () => {
     expect(classifyPositionals(['/api/orders'])).toEqual({ path: '/api/orders' })
   })
 
@@ -32,37 +38,41 @@ describe('classifyPositionals', () => {
     expect(classifyPositionals(['src/app.ts'])).toEqual({ file: 'src/app.ts' })
   })
 
-  it('an existing file wins over a method name', () => {
-    existsSync.mockReturnValue(true)
-    expect(classifyPositionals(['GET'])).toEqual({ file: 'GET' })
+  it('classifies file and path together', () => {
+    existsSync.mockImplementation((p) => String(p).endsWith('app.ts'))
+    expect(classifyPositionals(['src/app.ts', '/api/orders'])).toEqual({
+      file: 'src/app.ts',
+      path: '/api/orders',
+    })
   })
 
   it('keeps - as the stdin file', () => {
     expect(classifyPositionals(['-'])).toEqual({ file: '-' })
   })
 
-  it('classifies file, method, and path together', () => {
-    existsSync.mockImplementation((p) => String(p).endsWith('app.ts'))
-    expect(classifyPositionals(['src/app.ts', 'POST', '/api/orders'])).toEqual({
-      file: 'src/app.ts',
-      method: 'POST',
-      path: '/api/orders',
-    })
-  })
-
   it('treats a missing non-path argument as the app file', () => {
     expect(classifyPositionals(['missing.ts'])).toEqual({ file: 'missing.ts' })
   })
 
+  it('suggests -X for a method-like argument, with the given path', () => {
+    const error = expectCliError(
+      () => classifyPositionals(['GET', '/api/orders']),
+      'INVALID_ARGUMENTS'
+    )
+    expect(error.suggestions).toEqual(['Pass it with -X: hono request -X GET -P /api/orders'])
+  })
+
+  it('suggests -X for a method-like argument without a path', () => {
+    const error = expectCliError(() => classifyPositionals(['POST']), 'INVALID_ARGUMENTS')
+    expect(error.suggestions).toEqual(['Pass it with -X: hono request -X POST -P <path>'])
+  })
+
+  it('an existing file named like a method stays the app file', () => {
+    existsSync.mockReturnValue(true)
+    expect(classifyPositionals(['GET'])).toEqual({ file: 'GET' })
+  })
+
   it('throws INVALID_ARGUMENTS on two paths', () => {
-    expect(() => classifyPositionals(['/a', '/b'])).toThrowError(CliError)
-    try {
-      classifyPositionals(['/a', '/b'])
-    } catch (e) {
-      expect(e).toBeInstanceOf(CliError)
-      if (e instanceof CliError) {
-        expect(e.code).toBe('INVALID_ARGUMENTS')
-      }
-    }
+    expectCliError(() => classifyPositionals(['/a', '/b']), 'INVALID_ARGUMENTS')
   })
 })

--- a/src/commands/request/positionals.ts
+++ b/src/commands/request/positionals.ts
@@ -1,0 +1,54 @@
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { CliError } from '../../utils/output.js'
+
+const HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']
+
+export interface Positionals {
+  file?: string
+  method?: string
+  path?: string
+}
+
+/**
+ * Agents type curl-style arguments: `request GET /api/orders` or
+ * `request /api/orders`. Accept them. An existing file stays the app
+ * file, `-` stays stdin, an upper-case HTTP method sets the method,
+ * and a `/`-leading argument is the request path.
+ */
+export const classifyPositionals = (args: string[]): Positionals => {
+  const result: Positionals = {}
+
+  for (const arg of args) {
+    if (arg === '-' || existsSync(resolve(process.cwd(), arg))) {
+      assign(result, 'file', arg)
+      continue
+    }
+    if (HTTP_METHODS.includes(arg)) {
+      assign(result, 'method', arg)
+      continue
+    }
+    if (arg.startsWith('/')) {
+      assign(result, 'path', arg)
+      continue
+    }
+    // Not a method, not a path: treat as the app file. A missing file
+    // fails later with ENTRY_NOT_FOUND and its own suggestions.
+    assign(result, 'file', arg)
+  }
+
+  return result
+}
+
+const assign = (result: Positionals, key: keyof Positionals, value: string): void => {
+  if (result[key] !== undefined && result[key] !== value) {
+    throw new CliError(
+      'INVALID_ARGUMENTS',
+      `Two values for the ${key}: ${result[key]} and ${value}`,
+      {
+        suggestions: ['Request a path like: hono request -P /api/orders'],
+      }
+    )
+  }
+  result[key] = value
+}

--- a/src/commands/request/positionals.ts
+++ b/src/commands/request/positionals.ts
@@ -1,60 +1,62 @@
-import { existsSync } from 'node:fs'
-import { resolve } from 'node:path'
 import { CliError } from '../../utils/output.js'
 
 const HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']
 
 export interface Positionals {
-  file?: string
   path?: string
+  file?: string
 }
 
 /**
- * Accept curl-style arguments: like the URL in curl, a `/`-leading
- * argument is the request path. An existing file stays the app file,
- * and `-` stays stdin. curl takes no method argument, so a
- * method-like argument gets the exact `-X` command as a suggestion.
+ * The first argument of `request` is the request path, like the URL
+ * in curl. The second is the app file. A wrong shape is not
+ * interpreted — it returns the exact corrected command.
  */
-export const classifyPositionals = (args: string[]): Positionals => {
-  const result: Positionals = {}
-  const methods: string[] = []
-
-  for (const arg of args) {
-    if (arg === '-' || existsSync(resolve(process.cwd(), arg))) {
-      assign(result, 'file', arg)
-      continue
+export const resolvePositionals = (
+  pathArg: string | undefined,
+  fileArg: string | undefined,
+  batch: boolean
+): Positionals => {
+  if (batch) {
+    // Batch steps carry their own paths, so the only argument is the
+    // app file.
+    if (pathArg !== undefined && fileArg !== undefined) {
+      throw new CliError('INVALID_ARGUMENTS', 'Pass one app file with --batch', {
+        suggestions: ['hono request --batch - src/app.ts'],
+      })
     }
-    if (HTTP_METHODS.includes(arg)) {
-      methods.push(arg)
-      continue
+    if (pathArg?.startsWith('/')) {
+      throw new CliError('INVALID_ARGUMENTS', 'Batch steps carry their own paths', {
+        suggestions: ['Put the path in the batch lines'],
+      })
     }
-    if (arg.startsWith('/')) {
-      assign(result, 'path', arg)
-      continue
-    }
-    // Not a path: treat as the app file. A missing file fails later
-    // with ENTRY_NOT_FOUND and its own suggestions.
-    assign(result, 'file', arg)
+    return { file: pathArg }
   }
 
-  if (methods.length > 0) {
-    throw new CliError('INVALID_ARGUMENTS', 'The method is not an argument, like in curl', {
-      suggestions: [`Pass it with -X: hono request -X ${methods[0]} -P ${result.path ?? '<path>'}`],
+  if (pathArg === undefined) {
+    throw new CliError('INVALID_ARGUMENTS', 'The request path is required', {
+      suggestions: ['Request the root: hono request /'],
     })
   }
 
-  return result
-}
-
-const assign = (result: Positionals, key: keyof Positionals, value: string): void => {
-  if (result[key] !== undefined && result[key] !== value) {
+  if (!pathArg.startsWith('/')) {
+    if (HTTP_METHODS.includes(pathArg)) {
+      const path = fileArg?.startsWith('/') ? fileArg : '<path>'
+      throw new CliError('INVALID_ARGUMENTS', 'The method goes in -X, like curl', {
+        suggestions: [`hono request ${path} -X ${pathArg}`],
+      })
+    }
     throw new CliError(
       'INVALID_ARGUMENTS',
-      `Two values for the ${key}: ${result[key]} and ${value}`,
+      'The first argument is the request path, like the URL in curl',
       {
-        suggestions: ['Request a path like: hono request -P /api/orders'],
+        suggestions: [
+          `If ${pathArg} is the app file: hono request / ${pathArg}`,
+          `If it is the path: hono request /${pathArg}`,
+        ],
       }
     )
   }
-  result[key] = value
+
+  return { path: pathArg, file: fileArg }
 }

--- a/src/commands/request/positionals.ts
+++ b/src/commands/request/positionals.ts
@@ -6,18 +6,18 @@ const HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'
 
 export interface Positionals {
   file?: string
-  method?: string
   path?: string
 }
 
 /**
- * Agents type curl-style arguments: `request GET /api/orders` or
- * `request /api/orders`. Accept them. An existing file stays the app
- * file, `-` stays stdin, an upper-case HTTP method sets the method,
- * and a `/`-leading argument is the request path.
+ * Accept curl-style arguments: like the URL in curl, a `/`-leading
+ * argument is the request path. An existing file stays the app file,
+ * and `-` stays stdin. curl takes no method argument, so a
+ * method-like argument gets the exact `-X` command as a suggestion.
  */
 export const classifyPositionals = (args: string[]): Positionals => {
   const result: Positionals = {}
+  const methods: string[] = []
 
   for (const arg of args) {
     if (arg === '-' || existsSync(resolve(process.cwd(), arg))) {
@@ -25,16 +25,22 @@ export const classifyPositionals = (args: string[]): Positionals => {
       continue
     }
     if (HTTP_METHODS.includes(arg)) {
-      assign(result, 'method', arg)
+      methods.push(arg)
       continue
     }
     if (arg.startsWith('/')) {
       assign(result, 'path', arg)
       continue
     }
-    // Not a method, not a path: treat as the app file. A missing file
-    // fails later with ENTRY_NOT_FOUND and its own suggestions.
+    // Not a path: treat as the app file. A missing file fails later
+    // with ENTRY_NOT_FOUND and its own suggestions.
     assign(result, 'file', arg)
+  }
+
+  if (methods.length > 0) {
+    throw new CliError('INVALID_ARGUMENTS', 'The method is not an argument, like in curl', {
+      suggestions: [`Pass it with -X: hono request -X ${methods[0]} -P ${result.path ?? '<path>'}`],
+    })
   }
 
   return result

--- a/src/utils/output.test.ts
+++ b/src/utils/output.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { CliError, formatResult, formatError, handleErrors } from './output'
+import { CliError, formatArgumentsError, formatResult, formatError, handleErrors } from './output'
 
 describe('formatResult', () => {
   it('should wrap data in the envelope', () => {
@@ -30,6 +30,19 @@ describe('formatError', () => {
     expect(JSON.parse(formatError(error))).toEqual({
       ok: false,
       error: { code: 'UNEXPECTED_ERROR', message: 'boom' },
+    })
+  })
+})
+
+describe('formatArgumentsError', () => {
+  it('should turn a commander message into the envelope', () => {
+    expect(JSON.parse(formatArgumentsError("error: unknown option '--app'"))).toEqual({
+      ok: false,
+      error: {
+        code: 'INVALID_ARGUMENTS',
+        message: "unknown option '--app'",
+        suggestions: ['Check the usage: hono <command> --help'],
+      },
     })
   })
 })

--- a/src/utils/output.test.ts
+++ b/src/utils/output.test.ts
@@ -47,6 +47,15 @@ describe('formatArgumentsError', () => {
   })
 })
 
+describe('formatArgumentsError with -P', () => {
+  it('should point old -P calls at the positional path', () => {
+    const parsed = JSON.parse(formatArgumentsError("error: unknown option '-P'"))
+    expect(parsed.error.suggestions).toEqual([
+      'The path is the first argument: hono request /api/users',
+    ])
+  })
+})
+
 describe('handleErrors', () => {
   afterEach(() => {
     process.exitCode = undefined

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -33,6 +33,18 @@ export const formatError = (error: CliError): string =>
     2
   )
 
+/**
+ * Turn a commander parse error (unknown option, bad argument) into the
+ * JSON envelope, so argument mistakes get the same contract as command
+ * errors.
+ */
+export const formatArgumentsError = (message: string): string =>
+  formatError(
+    new CliError('INVALID_ARGUMENTS', message.replace(/^error: /, '').trim(), {
+      suggestions: ['Check the usage: hono <command> --help'],
+    })
+  )
+
 export const printResult = (data: unknown): void => {
   console.log(formatResult(data))
 }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -38,12 +38,14 @@ export const formatError = (error: CliError): string =>
  * JSON envelope, so argument mistakes get the same contract as command
  * errors.
  */
-export const formatArgumentsError = (message: string): string =>
-  formatError(
-    new CliError('INVALID_ARGUMENTS', message.replace(/^error: /, '').trim(), {
-      suggestions: ['Check the usage: hono <command> --help'],
-    })
-  )
+export const formatArgumentsError = (message: string): string => {
+  const cleaned = message.replace(/^error: /, '').trim()
+  // `-P` was removed in 0.2: the path became the first argument.
+  const suggestions = cleaned.includes("'-P'")
+    ? ['The path is the first argument: hono request /api/users']
+    : ['Check the usage: hono <command> --help']
+  return formatError(new CliError('INVALID_ARGUMENTS', cleaned, { suggestions }))
+}
 
 export const printResult = (data: unknown): void => {
   console.log(formatResult(data))


### PR DESCRIPTION
An agent-dx recording shows an agent trying `hono request GET /api/orders`, then `hono request "/api/orders"`, then a guessed `--app` — and giving up to write a throwaway script. The errors were commander's plain text, outside our JSON contract.

The fix, settled with Yusuke: one syntax, shaped like curl.

```bash
hono request <path> [file] [options]
```

- The first argument is the request path, like the URL in curl. It is required (`hono request /` for the root).
- The app file is the optional second argument. No heuristics — position decides.
- A wrong shape is never interpreted. It returns the exact corrected command in `suggestions`: `hono request GET /api/orders` answers with `hono request /api/orders -X GET`. Suggestion following is measured at 2/2.
- Argument parse errors (unknown option, bad argument) return the JSON envelope as `INVALID_ARGUMENTS`, like every other error.

**Breaking**: `-P` is removed (an old `-P` call gets a migration suggestion), and the path is now required — `hono request` alone no longer requests `/`. 0.2 is the breaking window.

Recorded in `docs/agent-dx-log.md`.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code