### PR TITLE
feat(routes): report notFound and onError handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,13 @@ hono routes [file] [options]
     "routes": [
       { "method": "GET", "path": "/", "name": "[handler]", "isMiddleware": false },
       { "method": "POST", "path": "/posts", "name": "[handler]", "isMiddleware": false }
-    ]
+    ],
+    "handlers": { "notFound": "custom", "onError": "default" }
   }
 }
 ```
+
+`handlers` reports whether the app sets its own `notFound` and `onError` handlers — a route list alone cannot show them. `unknown` means a wildcard route answered instead. When you refactor an app, compare the whole output before and after, handlers included.
 
 ### `request`
 

--- a/docs/agent-dx-log.md
+++ b/docs/agent-dx-log.md
@@ -3,6 +3,23 @@
 How measurements from [honojs/agent-dx](https://github.com/honojs/agent-dx)
 changed Hono CLI. Newest first.
 
+## 2026-09-03: A route diff misses notFound and onError — report them
+
+**Experiment**: `refactor-routes` — split a routes file, keep behavior.
+haiku, four onboarding channels, 5 runs each.
+
+**Findings**:
+
+- The main planted bug was a dropped `app.notFound()` during the
+  split. Agents that verified with `hono routes` before and after
+  still missed it: the handler is not a route, so the diff was clean.
+  A false negative from the verifier itself.
+
+**Changes**: `hono routes` output now has `handlers`, reporting
+whether the app sets its own `notFound` and `onError` (`custom` /
+`default` / `unknown` when a wildcard answers instead). The
+before-and-after diff catches the dropped handler now.
+
 ## 2026-09-03: Route count does not matter — locality does (no change)
 
 **Experiment**: `fix-404-large` — the same double-prefix mount bug in a

--- a/src/commands/routes/handlers.test.ts
+++ b/src/commands/routes/handlers.test.ts
@@ -1,0 +1,37 @@
+import { Hono } from 'hono'
+import { describe, it, expect } from 'vitest'
+import { inspectHandlers } from './handlers.js'
+
+describe('inspectHandlers', () => {
+  it('reports default handlers', async () => {
+    const app = new Hono()
+    app.get('/', (c) => c.text('hi'))
+    expect(await inspectHandlers(app)).toEqual({ notFound: 'default', onError: 'default' })
+  })
+
+  it('reports a custom notFound handler', async () => {
+    const app = new Hono()
+    app.notFound((c) => c.json({ error: 'not found' }, 404))
+    expect(await inspectHandlers(app)).toEqual({ notFound: 'custom', onError: 'default' })
+  })
+
+  it('reports a custom onError handler', async () => {
+    const app = new Hono()
+    app.onError((_, c) => c.json({ error: 'boom' }, 500))
+    expect(await inspectHandlers(app)).toEqual({ notFound: 'default', onError: 'custom' })
+  })
+
+  it('reports unknown when a wildcard route answers the probe', async () => {
+    const app = new Hono()
+    app.get('*', (c) => c.text('catch all'))
+    const result = await inspectHandlers(app)
+    expect(result.notFound).toBe('unknown')
+  })
+
+  it('sees through basePath and mounted sub-apps', async () => {
+    const app = new Hono().basePath('/api')
+    app.notFound((c) => c.json({ error: 'nope' }, 404))
+    const result = await inspectHandlers(app)
+    expect(result.notFound).toBe('custom')
+  })
+})

--- a/src/commands/routes/handlers.ts
+++ b/src/commands/routes/handlers.ts
@@ -1,0 +1,42 @@
+import type { Hono } from 'hono'
+import { randomUUID } from 'node:crypto'
+
+export type HandlerSource = 'custom' | 'default' | 'unknown'
+
+export interface Handlers {
+  notFound: HandlerSource
+  onError: HandlerSource
+}
+
+// `errorHandler` is public at runtime but private in the types.
+const readErrorHandler = (instance: unknown): unknown =>
+  (instance as { errorHandler?: unknown }).errorHandler
+
+/**
+ * Report whether the app sets its own notFound and onError handlers.
+ * A route diff misses them, so `routes` reports them directly.
+ */
+export const inspectHandlers = async (app: Hono): Promise<Handlers> => {
+  // A fresh instance of the same class holds the default errorHandler,
+  // so compare references.
+  let onError: HandlerSource = 'unknown'
+  try {
+    const AppClass = app.constructor as new () => unknown
+    onError = readErrorHandler(app) === readErrorHandler(new AppClass()) ? 'default' : 'custom'
+  } catch {
+    // a constructor that needs arguments
+  }
+
+  // The notFound handler is a private field. Probe a path that cannot
+  // match a real route, and compare to the default 404 response.
+  const response = await app.request(`/__hono_cli_probe__/${randomUUID()}`)
+  let notFound: HandlerSource
+  if (response.status !== 404) {
+    // A wildcard route or a middleware answered instead
+    notFound = 'unknown'
+  } else {
+    notFound = (await response.text()) === '404 Not Found' ? 'default' : 'custom'
+  }
+
+  return { notFound, onError }
+}

--- a/src/commands/routes/index.test.ts
+++ b/src/commands/routes/index.test.ts
@@ -75,6 +75,7 @@ describe('routesCommand', () => {
     const parsed = JSON.parse(consoleLogSpy.mock.calls[0][0])
     expect(parsed.ok).toBe(true)
     expect(typeof parsed.data.router).toBe('string')
+    expect(parsed.data.handlers).toEqual({ notFound: 'default', onError: 'default' })
     expect(parsed.data.routes).toEqual([
       { method: 'GET', path: '/', name: '[handler]', isMiddleware: false },
       { method: 'POST', path: '/posts', name: '[handler]', isMiddleware: false },

--- a/src/commands/routes/index.ts
+++ b/src/commands/routes/index.ts
@@ -3,15 +3,17 @@ import { getRouterName, inspectRoutes } from 'hono/dev'
 import type { CommandAgentContext } from '../../utils/agent-context.js'
 import { getBuildIterator } from '../../utils/load-app.js'
 import { CliError, handleErrors, printResult } from '../../utils/output.js'
+import { inspectHandlers } from './handlers.js'
 
 export const agentContext: CommandAgentContext = {
   output:
-    '{ "router": "SmartRouter + RegExpRouter", "routes": [{ "method": "GET", "path": "/", "name": "[handler]", "isMiddleware": false }] }',
+    '{ "router": "SmartRouter + RegExpRouter", "routes": [{ "method": "GET", "path": "/", "name": "[handler]", "isMiddleware": false }], "handlers": { "notFound": "custom", "onError": "default" } }',
   errors: ['ENTRY_NOT_FOUND', 'INVALID_APP'],
   examples: ['hono routes', 'hono routes --verbose src/app.ts'],
   notes: [
     'Routes are resolved from the real app instance, so mounted sub-apps and basePath are all expanded.',
     'Run it first to get the full picture of an app without reading the source.',
+    '"handlers" reports whether the app sets its own notFound and onError handlers — a route list alone cannot show them. When you refactor an app, compare the whole output before and after, handlers included.',
   ],
 }
 
@@ -52,6 +54,7 @@ export function routesCommand(program: Command) {
           ({ isMiddleware }) => options.verbose || !isMiddleware
         )
         const router = getRouterName(app)
+        const handlers = await inspectHandlers(app)
 
         if (options.plain) {
           const maxMethodLength = Math.max(...routes.map(({ method }) => method.length), 0)
@@ -61,7 +64,7 @@ export function routesCommand(program: Command) {
           return
         }
 
-        printResult({ router, routes })
+        printResult({ router, routes, handlers })
       })
     )
 }


### PR DESCRIPTION
In the agent-dx `refactor-routes` experiment, the planted bug was a dropped `app.notFound()` during a file split. Agents that verified with `hono routes` before and after still missed it: the handler is not a route, so the diff was clean — a false negative from the verifier itself.

`routes` output now has `handlers`:

```json
"handlers": { "notFound": "custom", "onError": "default" }
```

`onError` is read from the instance (compared with the default of the app's own class). `notFound` is a private field, so it is probed with one request to a random path — `unknown` means a wildcard route answered instead. Recorded in `docs/agent-dx-log.md`.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
