### PR TITLE
fix(test): skip npm audit and fund in the optimize tests

### DIFF
--- a/src/commands/optimize/index.test.ts
+++ b/src/commands/optimize/index.test.ts
@@ -22,7 +22,8 @@ const writePackageJSON = (dir: string, honoVersion: string = 'latest') => {
 
 const npmInstall = async () =>
   new Promise<void>((resolve) => {
-    const child = execFile('npm', ['install'])
+    // --no-audit: a hanging npm audit endpoint must not hang the tests
+    const child = execFile('npm', ['install', '--no-audit', '--no-fund'])
     child.on('exit', () => {
       resolve()
     })


### PR DESCRIPTION
The optimize tests run a real `npm install` per test. Today the npm audit endpoint (`/-/npm/v1/security/advisories/bulk`) stopped responding, and `npm install` waits for it forever — every CI job and local run hung in the optimize tests, with no code change (the same commits were green yesterday).

`--no-audit --no-fund` skips those endpoints, like `benchmark`'s installer already does. Verified: the suite hangs without the flags and passes with them, during the outage.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code