### PR TITLE
fix(build): fail with the envelope instead of hanging on a build error

### DIFF
--- a/docs/agent-dx-log.md
+++ b/docs/agent-dx-log.md
@@ -3,6 +3,28 @@
 How measurements from [honojs/agent-dx](https://github.com/honojs/agent-dx)
 changed Hono CLI. Newest first.
 
+## 2026-09-04: A failed build must fail, not hang
+
+**Experiment**: the `next.0` vs `next.1` A/B (haiku, 35 runs) — the
+first with the new CLI. Plus a recorded reproduction.
+
+**Findings**:
+
+- 3 of 35 runs were lost to a 600s timeout: `hono request` printed the
+  esbuild error and then never exited. A build failure (an unresolved
+  import — routine while developing) logged the error but never
+  resolved the internal promise, and the esbuild watch context kept
+  the process alive. Agent environments keep stdin open, so nothing
+  saved them.
+- For an agent the worst failure is not a wrong error — it is a silent
+  hang. An error envelope is recovered from 4/4 times; a hang eats the
+  whole run.
+
+**Changes**: a failed one-shot build now rejects: `BUILD_FAILED` (with
+the esbuild message) or `INVALID_APP`, as the JSON envelope with exit
+code 1, and the esbuild context is disposed. `--watch` keeps the old
+behavior: log and wait for the next change.
+
 ## 2026-09-03: Onboarding works as a policy, not as a tool list
 
 **Experiment**: `refactor-routes` — split a routes file, keep behavior.

--- a/src/commands/benchmark/index.ts
+++ b/src/commands/benchmark/index.ts
@@ -12,7 +12,14 @@ import { projectHonoSource, resolveHonoSource } from './hono-source.js'
 export const agentContext: CommandAgentContext = {
   output:
     '{ "results": [{ "hono": "4.13.0", "routes": [{ "method": "GET", "path": "/users", "requests": 48210, "rps": 96420, "latency": { "avg": 0.01, "p50": 0.009, "p75": 0.011, "p99": 0.021 } }] }] }',
-  errors: ['ENTRY_NOT_FOUND', 'INVALID_APP', 'NO_ROUTES', 'HONO_INSTALL_FAILED', 'BENCH_FAILED'],
+  errors: [
+    'ENTRY_NOT_FOUND',
+    'BUILD_FAILED',
+    'INVALID_APP',
+    'NO_ROUTES',
+    'HONO_INSTALL_FAILED',
+    'BENCH_FAILED',
+  ],
   examples: [
     'hono benchmark',
     'hono benchmark -P /users',

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -18,6 +18,8 @@ export const agentContext: CommandAgentContext = {
     '{ "status": 200, "headers": { "content-type": "application/json" }, "body": { "message": "Hello" } }',
   errors: [
     'ENTRY_NOT_FOUND',
+    'BUILD_FAILED',
+    'INVALID_APP',
     'RUNTIME_NOT_FOUND',
     'RUNTIME_FAILED',
     'WRANGLER_NOT_FOUND',

--- a/src/commands/routes/index.ts
+++ b/src/commands/routes/index.ts
@@ -7,7 +7,7 @@ import { CliError, handleErrors, printResult } from '../../utils/output.js'
 export const agentContext: CommandAgentContext = {
   output:
     '{ "router": "SmartRouter + RegExpRouter", "routes": [{ "method": "GET", "path": "/", "name": "[handler]", "isMiddleware": false }] }',
-  errors: ['ENTRY_NOT_FOUND', 'INVALID_APP'],
+  errors: ['ENTRY_NOT_FOUND', 'BUILD_FAILED', 'INVALID_APP'],
   examples: ['hono routes', 'hono routes --verbose src/app.ts'],
   notes: [
     'Routes are resolved from the real app instance, so mounted sub-apps and basePath are all expanded.',

--- a/src/commands/ssg/index.ts
+++ b/src/commands/ssg/index.ts
@@ -8,7 +8,7 @@ import { createRouteFilter } from './route-filter.js'
 
 export const agentContext: CommandAgentContext = {
   output: '{ "output": "static", "files": ["static/index.html", "static/about.html"] }',
-  errors: ['ENTRY_NOT_FOUND', 'SSG_FAILED'],
+  errors: ['ENTRY_NOT_FOUND', 'BUILD_FAILED', 'INVALID_APP', 'SSG_FAILED'],
   examples: ['hono ssg', 'hono ssg -o dist/static src/app.ts', "hono ssg --exclude '/api/*'"],
   notes: ['`--include` / `--exclude` select routes by path. `*` matches anything.'],
 }

--- a/src/utils/build.test.ts
+++ b/src/utils/build.test.ts
@@ -233,6 +233,83 @@ describe('buildAndImportApp', () => {
     await expect(buildIterator.next()).rejects.toThrow('Build failed')
   })
 
+  const setupCapturedOnEnd = () => {
+    let onEnd: OnEndCallback | undefined
+    mockEsbuild.mockImplementation(async (param: Parameters<typeof context>[0]) => {
+      param.plugins?.[0].setup({
+        onEnd: (cb: OnEndCallback) => {
+          onEnd = cb
+        },
+      } as PluginBuild)
+      return {
+        rebuild: vi.fn(),
+        watch: vi.fn(),
+        serve: vi.fn(),
+        cancel: vi.fn(),
+        dispose: mockEsbuildDispose,
+      }
+    })
+    return () => onEnd
+  }
+
+  const failedResult = {
+    errors: [
+      {
+        id: '',
+        pluginName: '',
+        text: 'Could not resolve "./missing.js"',
+        location: null,
+        notes: [],
+        detail: undefined,
+      },
+    ],
+    warnings: [],
+    outputFiles: undefined,
+    metafile: undefined,
+    mangleCache: undefined,
+  }
+
+  it('should reject with BUILD_FAILED instead of hanging when the build fails', async () => {
+    const getOnEnd = setupCapturedOnEnd()
+    const iterator = buildAndImportApp('/path/to/broken.ts')
+    const next = iterator.next()
+    await vi.waitFor(() => expect(getOnEnd()).toBeDefined())
+    await getOnEnd()!(failedResult)
+    await expect(next).rejects.toMatchObject({ code: 'BUILD_FAILED' })
+    expect(mockEsbuildDispose).toHaveBeenCalled()
+  })
+
+  it('should reject with INVALID_APP when the file exports no app', async () => {
+    setupBundledCode('export default 42;')
+    const iterator = buildAndImportApp('/path/to/app.ts')
+    await expect(iterator.next()).rejects.toMatchObject({ code: 'INVALID_APP' })
+  })
+
+  it('should keep watching after a failed build', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const getOnEnd = setupCapturedOnEnd()
+    const iterator = buildAndImportApp('/path/to/app.ts', { watch: true })
+    const next = iterator.next()
+    await vi.waitFor(() => expect(getOnEnd()).toBeDefined())
+    await getOnEnd()!(failedResult)
+    expect(consoleErrorSpy).toHaveBeenCalled()
+    // The next successful build still resolves the iterator
+    const mockApp = new Hono()
+    vi.stubGlobal('__buildTestApp', mockApp)
+    await getOnEnd()!({
+      errors: [],
+      warnings: [],
+      outputFiles: [
+        { path: '', contents: new Uint8Array(), hash: '', text: 'export default __buildTestApp;' },
+      ],
+      metafile: undefined,
+      mangleCache: undefined,
+    })
+    await expect(next).resolves.toMatchObject({ done: false })
+    vi.unstubAllGlobals()
+    consoleErrorSpy.mockRestore()
+  })
+
   it('should use default empty options when none provided', async () => {
     const mockApp = new Hono()
     const filePath = '/path/to/app.ts'

--- a/src/utils/build.ts
+++ b/src/utils/build.ts
@@ -1,6 +1,7 @@
 import * as esbuild from 'esbuild'
 import type { Plugin } from 'esbuild'
 import type { Hono } from 'hono'
+import { CliError } from './output.js'
 
 export interface BuildOptions {
   external?: string[]
@@ -32,14 +33,27 @@ export async function* buildAndImportApp(
   options: BuildOptions = {}
 ): AsyncGenerator<Hono> {
   let resolveApp: (app: Hono) => void
+  let rejectApp: (error: unknown) => void
   let appPromise: Promise<Hono>
 
   const preparePromise = () => {
-    appPromise = new Promise((resolve) => {
+    appPromise = new Promise((resolve, reject) => {
       resolveApp = resolve
+      rejectApp = reject
     })
   }
   preparePromise()
+
+  // In watch mode, a failed build logs and waits for the next change.
+  // In one-shot mode it must reject, so the process exits with the
+  // JSON envelope instead of hanging.
+  const fail = (error: unknown) => {
+    if (options.watch) {
+      console.error('Error building app', error)
+    } else {
+      rejectApp(error)
+    }
+  }
 
   const entryConfig = entryConfigOf(entry)
 
@@ -61,6 +75,14 @@ export async function* buildAndImportApp(
         name: 'watch',
         setup(build) {
           build.onEnd(async (result) => {
+            if (result.errors.length > 0) {
+              fail(
+                new CliError('BUILD_FAILED', result.errors.map((e) => e.text).join('\n'), {
+                  suggestions: ['Fix the build error in the app file'],
+                })
+              )
+              return
+            }
             try {
               // Execute the bundled code using data URL
               let code = result.outputFiles?.[0]?.text || ''
@@ -71,13 +93,11 @@ export async function* buildAndImportApp(
               const module = await import(dataUrl)
               const app = module.default
 
-              // Determine entry file path
-              if (!app) {
-                throw new Error('Failed to build app')
-              }
-
               if (!app || typeof app.request !== 'function') {
-                throw new Error('No valid Hono app exported from the file')
+                throw new CliError('INVALID_APP', 'No valid Hono app exported from the file', {
+                  suggestions: ['Export the Hono instance as the default export'],
+                  docs: 'https://hono.dev/docs/api/hono',
+                })
               }
 
               try {
@@ -86,7 +106,7 @@ export async function* buildAndImportApp(
                 // Ignore
               }
             } catch (error) {
-              console.error('Error building app', error)
+              fail(error)
             }
           })
         },
@@ -98,7 +118,14 @@ export async function* buildAndImportApp(
   await context.watch()
 
   do {
-    const app = await appPromise!
+    let app: Hono
+    try {
+      app = await appPromise!
+    } catch (error) {
+      // Dispose after the first build result. See issue #66.
+      await context.dispose()
+      throw error
+    }
     if (!options.watch) {
       // `context.dispose()` must be called after first build result to avoid race condition
       // https://github.com/honojs/cli/issues/66


### PR DESCRIPTION
The agent-dx A/B lost 3 of 35 runs to 600s timeouts: a failed build printed the esbuild error but the process never exited.

A failed one-shot build now rejects as `BUILD_FAILED` or `INVALID_APP` with exit code 1, and the esbuild context is disposed. `--watch` still logs and waits. Verified with the recorded repro, logged in `docs/agent-dx-log.md`.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code