### PR TITLE
fix(cli): map invented flags to the real ones in suggestions

### DIFF
--- a/docs/agent-dx-log.md
+++ b/docs/agent-dx-log.md
@@ -3,6 +3,23 @@
 How measurements from [honojs/agent-dx](https://github.com/honojs/agent-dx)
 changed Hono CLI. Newest first.
 
+## 2026-09-04: One skill line takes `--batch` from 0/40 to 5/5
+
+**Experiment**: `build-endpoints` x `next.2`, old skill vs
+honojs/skills#3 (the one `--batch` line). 5 runs each.
+
+**Findings**: adoption 0/5 → 5/5, median CLI calls 5 → 2, median
+tokens -36%. A feature off the rails does not exist; on them, it is
+used at once. 4/5 first batch calls hit an envelope error and all
+recovered — agents invented flags (`--body`, `-j`, `-m`) and guessed
+JSONL field names.
+
+**Changes**: unknown-option suggestions now map the common wrong
+guesses to the real flag (`--body`/`-j` → `-d`, `-m` → `-X`), like
+the `-P` migration hint. The skill gets a verbatim batch example
+(honojs/skills#4) — agents copy examples exactly, so a real one
+removes the guessing.
+
 ## 2026-09-04: A failed build must fail, not hang
 
 **Experiment**: the `next.0` vs `next.1` A/B (haiku, 35 runs) — the

--- a/src/utils/output.test.ts
+++ b/src/utils/output.test.ts
@@ -47,12 +47,19 @@ describe('formatArgumentsError', () => {
   })
 })
 
-describe('formatArgumentsError with -P', () => {
+describe('formatArgumentsError flag fixes', () => {
   it('should point old -P calls at the positional path', () => {
     const parsed = JSON.parse(formatArgumentsError("error: unknown option '-P'"))
     expect(parsed.error.suggestions).toEqual([
       'The path is the first argument: hono request /api/users',
     ])
+  })
+
+  it('should map an invented flag to the real one', () => {
+    const body = JSON.parse(formatArgumentsError("error: unknown option '--body'"))
+    expect(body.error.suggestions[0]).toContain('-d')
+    const method = JSON.parse(formatArgumentsError("error: unknown option '-m'"))
+    expect(method.error.suggestions[0]).toContain('-X')
   })
 })
 

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -38,12 +38,20 @@ export const formatError = (error: CliError): string =>
  * JSON envelope, so argument mistakes get the same contract as command
  * errors.
  */
+// Agents invent flags. Map the common wrong guesses to the real one.
+const FLAG_FIXES: Record<string, string> = {
+  '-P': 'The path is the first argument: hono request /api/users',
+  '--path': 'The path is the first argument: hono request /api/users',
+  '--body': `The body flag is -d: hono request /api/users -X POST -d '{"name":"Alice"}'`,
+  '-j': `The body flag is -d: hono request /api/users -X POST -d '{"name":"Alice"}'`,
+  '-m': 'The method flag is -X: hono request /api/users -X POST',
+}
+
 export const formatArgumentsError = (message: string): string => {
   const cleaned = message.replace(/^error: /, '').trim()
-  // `-P` was removed in 0.2: the path became the first argument.
-  const suggestions = cleaned.includes("'-P'")
-    ? ['The path is the first argument: hono request /api/users']
-    : ['Check the usage: hono <command> --help']
+  const flag = cleaned.match(/unknown option '([^']+)'/)?.[1]
+  const fix = flag ? FLAG_FIXES[flag] : undefined
+  const suggestions = [fix ?? 'Check the usage: hono <command> --help']
   return formatError(new CliError('INVALID_ARGUMENTS', cleaned, { suggestions }))
 }
 


### PR DESCRIPTION
In the skills#3 measurement, 4/5 first `--batch` calls hit an envelope error: agents invent flags (`--body`, `-j`, `-m`). All recovered, but each costs a round trip.

Unknown-option suggestions now map the common wrong guesses to the real flag, like the `-P` migration hint. Logged in `docs/agent-dx-log.md`.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code