### PR TITLE
fix(request): report a runtime build failure as BUILD_FAILED

### DIFF
--- a/src/commands/request/runtime.test.ts
+++ b/src/commands/request/runtime.test.ts
@@ -74,6 +74,27 @@ describe('buildRunnerBody', () => {
   })
 })
 
+describe('runInRuntime', () => {
+  it('should throw BUILD_FAILED before starting the runtime when the build fails', async () => {
+    const { runInRuntime } = await import('./runtime.js')
+    const { CliError } = await import('../../utils/output.js')
+    try {
+      await runInRuntime(
+        'bun',
+        { code: 'import x from "./missing-module.js"\nexport default x' },
+        [],
+        { path: '/', method: 'GET', headers: {} }
+      )
+      expect.unreachable()
+    } catch (e) {
+      expect(e).toBeInstanceOf(CliError)
+      if (e instanceof CliError) {
+        expect(e.code).toBe('BUILD_FAILED')
+      }
+    }
+  })
+})
+
 describe('parseRunnerOutput', () => {
   afterEach(() => {
     vi.restoreAllMocks()

--- a/src/commands/request/runtime.ts
+++ b/src/commands/request/runtime.ts
@@ -90,23 +90,30 @@ export const runInRuntime = async (
   const [importSource, plugins] =
     typeof entry === 'string' ? [entry, []] : ['virtual:app', [virtualAppPlugin(entry.code)]]
 
-  const built = await esbuild.build({
-    stdin: {
-      contents: `import app from ${JSON.stringify(importSource)}\n${body}`,
-      resolveDir: process.cwd(),
-      loader: 'tsx',
-      sourcefile: '__runner__.tsx',
-    },
-    bundle: true,
-    write: false,
-    format: 'esm',
-    target: 'esnext',
-    platform: 'node',
-    jsx: 'automatic',
-    jsxImportSource: 'hono/jsx',
-    external: ['@hono/node-server', ...external],
-    plugins,
-  })
+  let built: esbuild.BuildResult<{ write: false }>
+  try {
+    built = await esbuild.build({
+      stdin: {
+        contents: `import app from ${JSON.stringify(importSource)}\n${body}`,
+        resolveDir: process.cwd(),
+        loader: 'tsx',
+        sourcefile: '__runner__.tsx',
+      },
+      bundle: true,
+      write: false,
+      format: 'esm',
+      target: 'esnext',
+      platform: 'node',
+      jsx: 'automatic',
+      jsxImportSource: 'hono/jsx',
+      external: ['@hono/node-server', ...external],
+      plugins,
+    })
+  } catch (e) {
+    throw new CliError('BUILD_FAILED', e instanceof Error ? e.message : String(e), {
+      suggestions: ['Fix the build error in the app file'],
+    })
+  }
 
   const command = RUNNER_COMMANDS[runtime]
   const stdout = await execRunner(runtime, command, built.outputFiles[0].text)


### PR DESCRIPTION
An audit before the bindings experiment: a build failure on the bun/deno path returned `UNEXPECTED_ERROR` with no suggestions, unlike the node path (#118). It now throws `BUILD_FAILED` with the esbuild message, before the runtime starts.

No hang on any runtime error path — verified with the #118 repro against workerd and bun.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code