### PR TITLE
feat(request): bring back expect with a body match

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,15 +178,15 @@ hono request /api --runtime workerd
 # Run many requests in one call. One JSON object per line.
 # `save` stores a value from the response body, later steps use it as {{name}}.
 hono request --batch - <<'EOF'
-{"path":"/users"}
-{"method":"POST","path":"/users","body":{"name":"Momo"},"save":{"id":".id"}}
-{"path":"/users/{{id}}"}
-{"method":"DELETE","path":"/users/{{id}}"}
-{"path":"/users/{{id}}"}
+{"path":"/users","expect":{"status":200}}
+{"method":"POST","path":"/users","body":{"name":"Momo"},"expect":{"status":201,"body":{"name":"Momo"}},"save":{"id":".id"}}
+{"path":"/users/{{id}}","expect":{"status":200}}
+{"method":"DELETE","path":"/users/{{id}}","expect":{"status":204}}
+{"path":"/users/{{id}}","expect":{"status":404}}
 EOF
 ```
 
-A batch runs in order against one app instance, so in-memory state carries between steps. The output is one result per step — status and body as facts, for you to judge. A shared header from `-H` goes to every step.
+A batch runs in order against one app instance, so in-memory state carries between steps. Each step reports the actual `status` and `body`, and `expect` declares the acceptance criteria: `status` matches exactly, `body` is a deep partial match (declared fields must match, extra response fields are ignored). The output carries `pass` per step and a `summary` — rerun until `failed` is 0. A shared header from `-H` goes to every step.
 
 `workerd` starts the app with the wrangler config of the project, so pass no file argument. It needs [wrangler](https://developers.cloudflare.com/workers/wrangler/) installed in the project. wrangler is not a dependency of Hono CLI.
 

--- a/docs/agent-dx-log.md
+++ b/docs/agent-dx-log.md
@@ -3,6 +3,24 @@
 How measurements from [honojs/agent-dx](https://github.com/honojs/agent-dx)
 changed Hono CLI. Newest first.
 
+## 2026-09-05: `expect` returns — measurement beats our reasoning
+
+**Experiment**: an auto-mode task (build a shop API against an
+acceptance spec table), script vs hybrid vs CLI-only, 3 runs each.
+
+**Findings**: CLI-only was the fastest and cheapest (76k tokens, 48s)
+but lost runs the same way every condition did: the agent compared
+the spec table against the batch facts by eye and missed a line.
+Deterministic comparison across many lines is exactly what agents are
+bad at. We removed `expect` from `--batch` on reasoning (#114 — "the
+agent judges anyway"); the measurement says otherwise.
+
+**Changes**: `expect` is back, stronger: `{"status":201}` and/or
+`{"body":{...}}` — the body check is a deep partial match, which
+answers the original objection (a status-only pass hides a wrong
+body). Steps report `pass`, the batch reports a `summary` — the spec
+table becomes an executable check file, rerun until `failed` is 0.
+
 ## 2026-09-04: A verbatim example halves the tokens again
 
 **Experiment**: `build-endpoints` x `next.3` + the skill example

--- a/src/commands/request/batch.test.ts
+++ b/src/commands/request/batch.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { describe, it, expect } from 'vitest'
 import { CliError } from '../../utils/output.js'
-import { getByPath, interpolate, parseBatch, runBatch } from './batch.js'
+import { getByPath, interpolate, matchesSubset, parseBatch, runBatch } from './batch.js'
 
 describe('parseBatch', () => {
   it('parses one step per line and skips empty lines', () => {
@@ -17,6 +17,8 @@ describe('parseBatch', () => {
     ['no path', '{"method":"GET"}'],
     ['path without slash', '{"path":"users"}'],
     ['non-string save', '{"path":"/a","save":{"id":1}}'],
+    ['non-object expect', '{"path":"/a","expect":200}'],
+    ['unknown expect field', '{"path":"/a","expect":{"code":200}}'],
     ['empty input', '\n\n'],
   ])('throws BATCH_INVALID on %s', (_, input) => {
     try {
@@ -35,9 +37,14 @@ describe('interpolate', () => {
   it('replaces variables in strings, arrays, and objects', () => {
     expect(interpolate({ a: '/users/{{id}}', b: ['{{id}}'], c: 1 }, { id: 7 })).toEqual({
       a: '/users/7',
-      b: ['7'],
+      b: [7],
       c: 1,
     })
+  })
+
+  it('keeps the saved type when the string is exactly one variable', () => {
+    expect(interpolate('{{id}}', { id: 7 })).toBe(7)
+    expect(interpolate('/users/{{id}}', { id: 7 })).toBe('/users/7')
   })
 
   it('throws BATCH_INVALID on an unknown variable', () => {
@@ -50,6 +57,17 @@ describe('interpolate', () => {
         expect(e.code).toBe('BATCH_INVALID')
       }
     }
+  })
+})
+
+describe('matchesSubset', () => {
+  it('matches declared fields and ignores extras', () => {
+    expect(matchesSubset({ a: 1, b: 2 }, { a: 1 })).toBe(true)
+    expect(matchesSubset({ a: 1 }, { a: 2 })).toBe(false)
+    expect(matchesSubset({ a: { b: [1, 2] } }, { a: { b: [1, 2] } })).toBe(true)
+    expect(matchesSubset([1, 2], [1])).toBe(false)
+    expect(matchesSubset(null, null)).toBe(true)
+    expect(matchesSubset('x', { a: 1 })).toBe(false)
   })
 })
 
@@ -98,19 +116,60 @@ describe('runBatch', () => {
     expect(result.steps[1].body).toEqual({ id: 1, name: 'Momo' })
   })
 
-  it('reports the status and body as facts, without judging', async () => {
+  it('reports the status and body as facts', async () => {
     const result = await runBatch(crudApp(), parseBatch('{"path":"/nope"}'))
     expect(result.steps[0]).toEqual({
       method: 'GET',
       path: '/nope',
       status: 404,
       body: '404 Not Found',
+      pass: true,
     })
+    expect(result.summary).toEqual({ total: 1, passed: 1, failed: 0 })
   })
 
-  it('reports a save path missing from the body as an error fact', async () => {
+  it('checks expect.status and expect.body as a deep partial match', async () => {
+    const result = await runBatch(
+      crudApp(),
+      parseBatch(
+        [
+          '{"method":"POST","path":"/users","body":{"name":"Momo"},"expect":{"status":201,"body":{"name":"Momo"}},"save":{"id":".id"}}',
+          '{"path":"/users/{{id}}","expect":{"body":{"id":1,"name":"Momo"}}}',
+          '{"path":"/users/{{id}}","expect":{"body":{"name":"WRONG"}}}',
+        ].join('\n')
+      )
+    )
+    expect(result.steps[0].pass).toBe(true)
+    expect(result.steps[1].pass).toBe(true)
+    expect(result.steps[2].pass).toBe(false)
+    expect(result.summary).toEqual({ total: 3, passed: 2, failed: 1 })
+  })
+
+  it('fails a step on an expect.status mismatch and suggests --trace on 404', async () => {
+    const result = await runBatch(crudApp(), parseBatch('{"path":"/nope","expect":{"status":200}}'))
+    expect(result.steps[0].pass).toBe(false)
+    expect(result.steps[0].suggestions).toEqual([
+      'See which routes matched: hono request /nope --trace',
+    ])
+  })
+
+  it('interpolates saved values inside expect', async () => {
+    const result = await runBatch(
+      crudApp(),
+      parseBatch(
+        [
+          '{"method":"POST","path":"/users","body":{"name":"Momo"},"save":{"name":".name"}}',
+          '{"path":"/users/1","expect":{"body":{"name":"{{name}}"}}}',
+        ].join('\n')
+      )
+    )
+    expect(result.steps[1].pass).toBe(true)
+  })
+
+  it('reports a save path missing from the body as a failure', async () => {
     const result = await runBatch(crudApp(), parseBatch('{"path":"/users","save":{"id":".id"}}'))
     expect(result.steps[0].error).toBe('save: .id not found in the body')
+    expect(result.steps[0].pass).toBe(false)
     expect(result.steps[0].saved).toBeUndefined()
   })
 

--- a/src/commands/request/batch.ts
+++ b/src/commands/request/batch.ts
@@ -1,11 +1,17 @@
 import type { Hono } from 'hono'
 import { CliError } from '../../utils/output.js'
 
+export interface StepExpect {
+  status?: number
+  body?: unknown
+}
+
 export interface BatchStep {
   method: string
   path: string
   body?: unknown
   headers?: Record<string, string>
+  expect?: StepExpect
   save?: Record<string, string>
 }
 
@@ -14,18 +20,22 @@ export interface StepResult {
   path: string
   status: number
   body: unknown
+  pass: boolean
+  expect?: StepExpect
   saved?: Record<string, unknown>
   error?: string
+  suggestions?: string[]
 }
 
 export interface BatchResult {
   steps: StepResult[]
+  summary: { total: number; passed: number; failed: number }
 }
 
 const invalid = (message: string): CliError =>
   new CliError('BATCH_INVALID', message, {
     suggestions: [
-      'Each line is one JSON object: {"method":"POST","path":"/users","body":{"name":"Momo"},"save":{"id":".id"}}. A later step uses a saved value as {{id}}',
+      'Each line is one JSON object: {"method":"POST","path":"/users","body":{"name":"Momo"},"expect":{"status":201},"save":{"id":".id"}}. A later step uses a saved value as {{id}}',
     ],
   })
 
@@ -56,6 +66,11 @@ export const parseBatch = (input: string): BatchStep[] => {
     if (step.method !== undefined && typeof step.method !== 'string') {
       throw invalid(`Line ${i + 1}: "method" must be a string`)
     }
+    if (step.expect !== undefined && !isValidExpect(step.expect)) {
+      throw invalid(
+        `Line ${i + 1}: "expect" is an object like {"status":201} or {"status":200,"body":{"name":"Momo"}}`
+      )
+    }
     if (step.headers !== undefined && !isStringRecord(step.headers)) {
       throw invalid(`Line ${i + 1}: "headers" must be an object of strings`)
     }
@@ -67,6 +82,7 @@ export const parseBatch = (input: string): BatchStep[] => {
       path: step.path,
       body: step.body,
       headers: step.headers,
+      expect: step.expect as StepExpect | undefined,
       save: step.save,
     })
   }
@@ -74,6 +90,41 @@ export const parseBatch = (input: string): BatchStep[] => {
     throw invalid('The batch input is empty')
   }
   return steps
+}
+
+const isValidExpect = (value: unknown): value is StepExpect => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+  const expect = value as Record<string, unknown>
+  if (expect.status !== undefined && typeof expect.status !== 'number') {
+    return false
+  }
+  return Object.keys(expect).every((key) => key === 'status' || key === 'body')
+}
+
+/**
+ * Deep partial match, like `toMatchObject`: declared fields must
+ * match, extra fields in the actual value are ignored. Arrays match
+ * by index and length.
+ */
+export const matchesSubset = (actual: unknown, expected: unknown): boolean => {
+  if (Array.isArray(expected)) {
+    return (
+      Array.isArray(actual) &&
+      actual.length === expected.length &&
+      expected.every((item, i) => matchesSubset(actual[i], item))
+    )
+  }
+  if (typeof expected === 'object' && expected !== null) {
+    if (typeof actual !== 'object' || actual === null || Array.isArray(actual)) {
+      return false
+    }
+    return Object.entries(expected).every(([key, value]) =>
+      matchesSubset((actual as Record<string, unknown>)[key], value)
+    )
+  }
+  return actual === expected
 }
 
 const isStringRecord = (value: unknown): value is Record<string, string> =>
@@ -88,6 +139,15 @@ const isStringRecord = (value: unknown): value is Record<string, string> =>
  */
 export const interpolate = <T>(value: T, vars: Record<string, unknown>): T => {
   if (typeof value === 'string') {
+    // A string that is exactly one variable keeps the saved type, so
+    // a saved number stays a number in bodies and expects.
+    const whole = value.match(/^\{\{(\w+)\}\}$/)
+    if (whole) {
+      if (!(whole[1] in vars)) {
+        throw invalid(`Unknown variable {{${whole[1]}}}. Save it in an earlier step`)
+      }
+      return vars[whole[1]] as T
+    }
     return value.replace(/\{\{(\w+)\}\}/g, (_, name: string) => {
       if (!(name in vars)) {
         throw invalid(`Unknown variable {{${name}}}. Save it in an earlier step`)
@@ -128,8 +188,10 @@ export const getByPath = (body: unknown, path: string): unknown => {
 
 /**
  * Run the steps in order against one app instance, so in-memory state
- * carries from step to step. The result reports facts only — the
- * statuses and bodies. Judging them is the caller's job.
+ * carries from step to step. Each result carries the facts — status
+ * and body — and, when the step declares `expect`, the deterministic
+ * check against them. Agents miss lines when they compare a spec
+ * table by eye, so the comparison belongs to the CLI.
  */
 export const runBatch = async (
   app: Hono,
@@ -175,6 +237,20 @@ export const runBatch = async (
       path,
       status: response.status,
       body,
+      pass: true,
+      ...(step.expect === undefined ? {} : { expect: interpolate(step.expect, vars) }),
+    }
+
+    if (result.expect !== undefined) {
+      const statusOk =
+        result.expect.status === undefined || response.status === result.expect.status
+      const bodyOk = result.expect.body === undefined || matchesSubset(body, result.expect.body)
+      if (!statusOk || !bodyOk) {
+        result.pass = false
+        if (response.status === 404) {
+          result.suggestions = [`See which routes matched: hono request ${path} --trace`]
+        }
+      }
     }
 
     if (step.save) {
@@ -182,6 +258,7 @@ export const runBatch = async (
       for (const [name, savePath] of Object.entries(step.save)) {
         const value = getByPath(body, savePath)
         if (value === undefined) {
+          result.pass = false
           result.error = `save: ${savePath} not found in the body`
         } else {
           vars[name] = value
@@ -196,5 +273,9 @@ export const runBatch = async (
     results.push(result)
   }
 
-  return { steps: results }
+  const passed = results.filter((r) => r.pass).length
+  return {
+    steps: results,
+    summary: { total: results.length, passed, failed: results.length - passed },
+  }
 }

--- a/src/commands/request/index.test.ts
+++ b/src/commands/request/index.test.ts
@@ -118,7 +118,7 @@ describe('requestCommand', () => {
     const mockApp = new Hono()
     mockApp.get('/data', (c) => c.json({ ok: 1 }))
     setupBasicMocks('test-app.js', mockApp)
-    mockModules.readFileSync.mockReturnValue('{"path":"/data"}')
+    mockModules.readFileSync.mockReturnValue('{"path":"/data","expect":{"status":200}}')
     await program.parseAsync(['node', 'test', 'request', '--batch', 'steps.jsonl', 'test-app.js'])
     expect(JSON.parse(consoleLogSpy.mock.calls[0][0])).toEqual({
       ok: true,
@@ -129,8 +129,11 @@ describe('requestCommand', () => {
             path: '/data',
             status: 200,
             body: { ok: 1 },
+            pass: true,
+            expect: { status: 200 },
           },
         ],
+        summary: { total: 1, passed: 1, failed: 0 },
       },
     })
   })

--- a/src/commands/request/index.ts
+++ b/src/commands/request/index.ts
@@ -36,9 +36,9 @@ export const agentContext: CommandAgentContext = {
     'hono request /api --runtime workerd',
     `echo 'app.get("/hello", (c) => c.json({ ok: true }))' | hono request /hello -`,
     `hono request --batch - <<'EOF'
-{"path":"/users"}
-{"method":"POST","path":"/users","body":{"name":"Momo"},"save":{"id":".id"}}
-{"path":"/users/{{id}}"}
+{"path":"/users","expect":{"status":200}}
+{"method":"POST","path":"/users","body":{"name":"Momo"},"expect":{"status":201,"body":{"name":"Momo"}},"save":{"id":".id"}}
+{"path":"/users/{{id}}","expect":{"status":200}}
 EOF`,
   ],
   notes: [
@@ -48,8 +48,8 @@ EOF`,
     '--runtime runs the app on bun, deno, or workerd instead of Node.js. bun and deno must be installed. workerd starts the app with the wrangler config of the project, so the local bindings (c.env) are real — it needs wrangler installed and no file argument.',
     '--trace adds matchedRoutes to the output: which middleware and handler matched, and which one responded. Use it to debug an unexpected response. A 404 result includes a suggestion to run it.',
     'A JSON response body is embedded as an object. A binary body becomes null with "binary": true — save it with -o.',
-    '--batch runs many requests in one call, in order, against one app instance — in-memory state carries between steps. One JSON object per line: {"method","path","body","headers","save"}. "save" stores a value from the response body by dot path (e.g. {"id":".id"}), and later steps use it as {{id}}. Prefer --batch over writing a test script: no file to clean up.',
-    'The --batch output is one result per step: status and body as facts. Compare them with what you expect — read the bodies too, a right status can hide a wrong body.',
+    '--batch runs many requests in one call, in order, against one app instance — in-memory state carries between steps. One JSON object per line: {"method","path","body","headers","expect","save"}. "save" stores a value from the response body by dot path (e.g. {"id":".id"}), and later steps use it as {{id}}. Prefer --batch over writing a test script: no file to clean up.',
+    'Declare the acceptance criteria in "expect": {"status":201} and/or {"body":{...}} (a deep partial match — declared fields must match, extra response fields are ignored). The CLI checks every line for you and reports "pass" per step and a summary — turn the spec into batch lines and rerun until "failed" is 0. Comparing a spec table by eye misses lines.',
   ],
 }
 


### PR DESCRIPTION
The auto-mode measurement showed the failure we designed for: agents compare a spec table against batch facts by eye and miss lines. We removed `expect` on reasoning (#114); the measurement asks for it back.

`expect` takes `{"status":201}` and/or `{"body":{...}}` — the body check is a deep partial match, which answers the original objection (a status-only pass can hide a wrong body). Steps report `pass`, the batch a `summary`: the spec table becomes an executable check file, rerun until `failed` is 0. A whole-variable string like `"{{id}}"` keeps the saved type. Logged in `docs/agent-dx-log.md`.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code