### PR TITLE
fix(trace): use matchedRoutes from hono/route

### DIFF
--- a/src/commands/request/trace.ts
+++ b/src/commands/request/trace.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import type { MiddlewareHandler } from 'hono'
+import { matchedRoutes } from 'hono/route'
 import type { RouterRoute } from 'hono/types'
 import { findTargetHandler, isMiddleware } from 'hono/utils/handler'
 
@@ -26,7 +27,8 @@ export const withTracer = (app: Hono): { app: Hono; getTrace: () => TraceEntry[]
   let matched: Matched | undefined
   const tracer: MiddlewareHandler = async (c, next) => {
     await next()
-    matched = { routes: c.req.matchedRoutes, index: c.req.routeIndex, status: c.res.status }
+    // matchedRoutes(c) from hono/route: c.req.matchedRoutes is deprecated
+    matched = { routes: matchedRoutes(c), index: c.req.routeIndex, status: c.res.status }
   }
   const wrapper = new Hono()
   wrapper.use(tracer)


### PR DESCRIPTION
`c.req.matchedRoutes` is deprecated since hono v4.8.0 — the Route Helper's `matchedRoutes(c)` is the replacement. `c.req.routeIndex` stays: it has no helper equivalent.

Found while fact-checking the talk: the dev-helper docs also miss `inspectRoutes()`, which `hono routes` is built on — that one is a hono.dev docs item.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code